### PR TITLE
remaining V2 fixes

### DIFF
--- a/script/DeployV2ToTestnet.s.sol
+++ b/script/DeployV2ToTestnet.s.sol
@@ -137,9 +137,6 @@ contract DeployV2ToTestnet is Script {
         trustBonding = TrustBonding(address(trustBondingProxy));
         console.log("TrustBonding proxy address: ", address(trustBondingProxy));
 
-        // initialize the TrustBonding contract
-        trustBonding.initialize(admin, address(trustToken), epochLength, block.timestamp + 10 minutes);
-
         // define the config structs
         generalConfig = GeneralConfig({
             admin: admin,
@@ -223,8 +220,16 @@ contract DeployV2ToTestnet is Script {
         // initialize the WrappedERC20Factory contract
         wrappedERC20Factory.initialize(address(multiVault));
 
-        // reinitialize the TrustBonding contract to V2
-        trustBonding.reinitialize(address(multiVault), systemUtilizationLowerBound, personalUtilizationLowerBound);
+        // initialize the TrustBonding contract
+        trustBonding.initialize(
+            admin,
+            address(trustToken),
+            epochLength,
+            block.timestamp + 10 minutes,
+            address(multiVault),
+            systemUtilizationLowerBound,
+            personalUtilizationLowerBound
+        );
 
         // deploy the TrustVestedMerkleDistributor implementation contract
         trustVestedMerkleDistributor = new TrustVestedMerkleDistributor();

--- a/src/MultiVault.sol
+++ b/src/MultiVault.sol
@@ -50,6 +50,9 @@ contract MultiVault is IMultiVault, Initializable, ReentrancyGuardUpgradeable {
     /// @notice Constant representing 1 share in the vault (1e18)
     uint256 public constant ONE_SHARE = 1e18;
 
+    /// @notice Constant representing the burn address, which receives the "ghost shares"
+    address public constant BURN_ADDRESS = address(1);
+
     /* =================================================== */
     /*                  STATE VARIABLES                    */
     /* =================================================== */
@@ -882,7 +885,7 @@ contract MultiVault is IMultiVault, Initializable, ReentrancyGuardUpgradeable {
                 vaults[termId][bondingCurveId].totalShares + sharesForReceiver + minShare
             );
 
-            _mint(generalConfig.admin, termId, bondingCurveId, minShare);
+            _mint(BURN_ADDRESS, termId, bondingCurveId, minShare);
             _mint(receiver, termId, bondingCurveId, sharesForReceiver);
 
             if (isTripleVault) {
@@ -893,7 +896,7 @@ contract MultiVault is IMultiVault, Initializable, ReentrancyGuardUpgradeable {
                     vaults[counterTripleId][bondingCurveId].totalAssets + minShare,
                     vaults[counterTripleId][bondingCurveId].totalShares + minShare
                 );
-                _mint(generalConfig.admin, counterTripleId, bondingCurveId, minShare);
+                _mint(BURN_ADDRESS, counterTripleId, bondingCurveId, minShare);
             }
         } else {
             // If not creation, just update the vault totals and mint shares for the user
@@ -949,7 +952,7 @@ contract MultiVault is IMultiVault, Initializable, ReentrancyGuardUpgradeable {
         bytes32 termId,
         uint256 bondingCurveId,
         uint256 minAssetsToReceive
-    ) external nonReentrant returns (uint256) {
+    ) external whenNotPaused nonReentrant returns (uint256) {
         if (!isApprovedToRedeem(msg.sender, receiver)) {
             revert Errors.MultiVault_RedeemerNotApproved();
         }
@@ -1255,7 +1258,7 @@ contract MultiVault is IMultiVault, Initializable, ReentrancyGuardUpgradeable {
         _mint(receiver, termId, defaultBondingCurveId, sharesForReceiver);
 
         // Mint ghost shares to admin
-        _mint(generalConfig.admin, termId, defaultBondingCurveId, generalConfig.minShare);
+        _mint(BURN_ADDRESS, termId, defaultBondingCurveId, generalConfig.minShare);
 
         // Initialize the counter triple vault if it's a triple creation flow
         if (isTripleId(termId)) {
@@ -1281,7 +1284,7 @@ contract MultiVault is IMultiVault, Initializable, ReentrancyGuardUpgradeable {
         );
 
         // Mint ghost shares to admin for the counter vault
-        _mint(generalConfig.admin, counterTripleId, defaultBondingCurveId, generalConfig.minShare);
+        _mint(BURN_ADDRESS, counterTripleId, defaultBondingCurveId, generalConfig.minShare);
     }
 
     /// @dev mint vault shares to address `to`

--- a/src/interfaces/ITrustBonding.sol
+++ b/src/interfaces/ITrustBonding.sol
@@ -63,9 +63,11 @@ interface ITrustBonding {
                                  FUNCTIONS
     //////////////////////////////////////////////////////////////*/
 
-    function initialize(address _owner, address _trustToken, uint256 _epochLength, uint256 _startTimestamp) external;
-
-    function reinitialize(
+    function initialize(
+        address _owner,
+        address _trustToken,
+        uint256 _epochLength,
+        uint256 _startTimestamp,
         address _multiVault,
         uint256 _systemUtilizationLowerBound,
         uint256 _personalUtilizationLowerBound

--- a/src/v2/MultiVaultConfig.sol
+++ b/src/v2/MultiVaultConfig.sol
@@ -117,11 +117,15 @@ contract MultiVaultConfig is IMultiVaultConfig, Initializable, AccessControlUpgr
     /// @dev pauses the pausable contract methods
     function pause() external onlyRole(PAUSER_ROLE) {
         _pause();
+
+        multiVault.syncConfig();
     }
 
     /// @dev unpauses the pausable contract methods
     function unpause() external onlyRole(DEFAULT_ADMIN_ROLE) {
         _unpause();
+
+        multiVault.syncConfig();
     }
 
     /// @dev set the address of the MultiVault contract

--- a/test/MultiVaultBase.sol
+++ b/test/MultiVaultBase.sol
@@ -134,9 +134,6 @@ contract MultiVaultBase is Test {
             new TransparentUpgradeableProxy(address(trustBonding), admin, "");
         trustBonding = TrustBonding(address(trustBondingProxy));
 
-        // initialize the TrustBonding contract
-        trustBonding.initialize(admin, address(trustToken), epochLength, block.timestamp + 1);
-
         // define the config structs
         generalConfig = GeneralConfig({
             admin: admin,
@@ -213,9 +210,16 @@ contract MultiVaultBase is Test {
         // initialize the WrappedERC20Factory contract
         wrappedERC20Factory.initialize(address(multiVault));
 
-        // reinitialize the TrustBonding contract to V2 to enable utilization-based reward distribution
-        vm.prank(admin);
-        trustBonding.reinitialize(address(multiVault), systemUtilizationLowerBound, personalUtilizationLowerBound);
+        // initialize the TrustBonding contract
+        trustBonding.initialize(
+            admin,
+            address(trustToken),
+            epochLength,
+            block.timestamp + 1,
+            address(multiVault),
+            systemUtilizationLowerBound,
+            personalUtilizationLowerBound
+        );
 
         // deploy the AtomWarden contract
         atomWarden = new AtomWarden();

--- a/test/unit/MultiVault/Deposit.t.sol
+++ b/test/unit/MultiVault/Deposit.t.sol
@@ -75,7 +75,7 @@ contract DepositTest is MultiVaultBase {
         uint256 minShare = getGeneralConfig().minShare;
         (uint256 totalShares,) = multiVault.getVaultTotals(atomId, curve);
         assertEq(totalShares, minted + minShare);
-        assertEq(multiVault.balanceOf(getGeneralConfig().admin, atomId, curve), minShare);
+        assertEq(multiVault.balanceOf(multiVault.BURN_ADDRESS(), atomId, curve), minShare);
     }
 
     /// deposit into triple vault (no counter-stake)

--- a/test/unit/MultiVault/Redeem.t.sol
+++ b/test/unit/MultiVault/Redeem.t.sol
@@ -63,31 +63,7 @@ contract RedeemTest is MultiVaultBase {
     }
 
     /*──────────────────────────────────────────────────────────────────────────
-                              2. redeem while paused
-    ──────────────────────────────────────────────────────────────────────────*/
-
-    function test_redeem_noFeesWhenPaused() external {
-        bytes32 id = _createNewAtom();
-        uint256 val = 4 ether;
-        uint256 sh = _depositFor(address(this), id, val);
-
-        // pause config & sync
-        vm.prank(admin);
-        multiVaultConfig.pause();
-        multiVault.syncConfig();
-        assertTrue(multiVault.paused());
-
-        uint256 balBefore = trustToken.balanceOf(address(this));
-        uint256 assets = multiVault.redeem(sh, address(this), id, _defCurve(), _minAmount(val, defaultSlippage));
-
-        // received exactly convertToAssets (no fee deductions)
-        uint256 expected = multiVault.convertToAssets(sh, id, _defCurve());
-        assertApproxEqAbs(assets, expected, 1);
-        assertApproxEqAbs(trustToken.balanceOf(address(this)), balBefore + expected, 1);
-    }
-
-    /*──────────────────────────────────────────────────────────────────────────
-                              3. revert branches
+                              2. revert branches
     ──────────────────────────────────────────────────────────────────────────*/
 
     function test_redeem_revertIfRedeemerNotApproved() external {
@@ -136,15 +112,17 @@ contract RedeemTest is MultiVaultBase {
 
         multiVault.redeem(userShares, address(this), id, defaultCurveId, _minAmount(previewAssets, defaultSlippage)); // redeem all user shares so that only minShare remains
 
-        uint256 adminRedeemAmount = 1;
-        uint256 remainingShares = minShare - adminRedeemAmount;
-        previewAssets = multiVault.previewRedeem(adminRedeemAmount, id, defaultCurveId); // previewAssets is the amount of assets we expect to get back
+        uint256 burnAddressRedeemAmount = 1;
+        uint256 remainingShares = minShare - burnAddressRedeemAmount;
+        previewAssets = multiVault.previewRedeem(burnAddressRedeemAmount, id, defaultCurveId); // previewAssets is the amount of assets we expect to get back
 
-        vm.prank(admin);
+        address burnAddress = multiVault.BURN_ADDRESS();
+
+        vm.prank(burnAddress);
         vm.expectRevert(
             abi.encodeWithSelector(Errors.MultiVault_InsufficientRemainingSharesInVault.selector, remainingShares)
         );
-        multiVault.redeem(1, admin, id, defaultCurveId, _minAmount(previewAssets, defaultSlippage));
+        multiVault.redeem(1, burnAddress, id, defaultCurveId, _minAmount(previewAssets, defaultSlippage));
     }
 
     function test_redeem_revertIfTermInvalid() external {
@@ -161,7 +139,7 @@ contract RedeemTest is MultiVaultBase {
     }
 
     /*──────────────────────────────────────────────────────────────────────────
-                                4. batchRedeem
+                                3. batchRedeem
     ──────────────────────────────────────────────────────────────────────────*/
 
     function test_batchRedeem_happyPath() external {

--- a/test/unit/utils/TrustUnlock.t.sol
+++ b/test/unit/utils/TrustUnlock.t.sol
@@ -64,10 +64,15 @@ contract TrustUnlockTest is Test {
         trustBonding = TrustBonding(address(trustBondingProxy));
 
         // Initialize TrustBonding contract
-        trustBonding.initialize(owner, address(trustToken), epochLength_, startTimestamp);
-
-        // Reinitialize TrustBonding contract with MultiVault and utilization bounds
-        trustBonding.reinitialize(address(multiVault), systemUtilizationLowerBound, personalUtilizationLowerBound);
+        trustBonding.initialize(
+            owner,
+            address(trustToken),
+            epochLength_,
+            startTimestamp,
+            address(multiVault),
+            systemUtilizationLowerBound,
+            personalUtilizationLowerBound
+        );
 
         // Mint tokens to the owner
         trustToken.mint(owner, unlockAmount);

--- a/test/unit/utils/TrustUnlockFactory.t.sol
+++ b/test/unit/utils/TrustUnlockFactory.t.sol
@@ -41,6 +41,7 @@ contract TrustUnlockFactoryTest is Test {
     address public bob = makeAddr("bob");
     address public charlie = makeAddr("charlie");
     address public rescueAcct = makeAddr("rescuer");
+    address public multiVault = makeAddr("multiVault");
 
     /// @notice TrustUnlock config
     uint256 public constant UNLOCK_AMOUNT = 500_000 * 1e18;
@@ -48,6 +49,8 @@ contract TrustUnlockFactoryTest is Test {
     uint256 public constant CLIFF_PCT = 2_500; // 25 %
     uint256 public constant ONE_WEEK = 1 weeks;
     uint256 public constant ONE_YEAR = 365 days;
+    uint256 public constant systemUtilizationLowerBound = 2_500;
+    uint256 public constant personalUtilizationLowerBound = 2_500;
     uint256 public unlockBegin;
     uint256 public unlockCliff;
     uint256 public unlockEnd;
@@ -71,7 +74,17 @@ contract TrustUnlockFactoryTest is Test {
         TrustBonding logic = new TrustBonding();
         TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(address(logic), owner, "");
         trustBonding = TrustBonding(address(proxy));
-        trustBonding.initialize(owner, address(trustToken), 14 days, block.timestamp + 1 hours);
+
+        // Initialize TrustBonding contract
+        trustBonding.initialize(
+            owner,
+            address(trustToken),
+            epochLength,
+            startTime,
+            address(multiVault),
+            systemUtilizationLowerBound,
+            personalUtilizationLowerBound
+        );
 
         // 3. Deploy factory, fund it with tokens
         factory = new TrustUnlockFactory(address(trustToken), owner, address(trustBonding));

--- a/test/unit/utils/TrustVestedMerkleDistributor.t.sol
+++ b/test/unit/utils/TrustVestedMerkleDistributor.t.sol
@@ -18,6 +18,9 @@ import {MockTrust} from "test/mocks/MockTrust.t.sol";
 contract MockTrustBonding {
     using SafeERC20 for IERC20;
 
+    uint256 public constant MAXTIME = 2 * 365 * 86400;
+    uint256 public constant MINTIME = 2 weeks;
+
     struct LockedBalance {
         int128 amount;
         uint256 end;

--- a/test/unit/utils/TrustVestingAndUnlock.t.sol
+++ b/test/unit/utils/TrustVestingAndUnlock.t.sol
@@ -69,10 +69,15 @@ contract TrustVestingAndUnlockTest is Test {
         trustBonding = TrustBonding(address(trustBondingProxy));
 
         // Initialize TrustBonding contract
-        trustBonding.initialize(admin, address(trustToken), epochLength_, startTimestamp);
-
-        // Reinitialize TrustBonding contract with MultiVault and utilization bounds
-        trustBonding.reinitialize(address(multiVault), systemUtilizationLowerBound, personalUtilizationLowerBound);
+        trustBonding.initialize(
+            admin,
+            address(trustToken),
+            epochLength_,
+            startTimestamp,
+            address(multiVault),
+            systemUtilizationLowerBound,
+            personalUtilizationLowerBound
+        );
 
         // Deploy TrustVestingAndUnlock contract
         vestingBegin = block.timestamp;


### PR DESCRIPTION
Fixes included:

- Redeems are now also pausable
- Full config syncing on pause/unpause
- Expired lockup edge case in `TrustVestedMerkleDistributor`, as well as better `unlockTime` validation
- Burn address receives ghost shares instead of `generalConfig.admin`
- Merge `initialize` & `reinitialize` functions in `TrustBonding`
- Got rid of max possible bonding APY
- Added multiple roles to the `TrustBonding` contract, including `PAUSER_ROLE` and `TIMELOCK_ROLE`
- Unit test fixes related to the features outlined above