### PR TITLE
switch to using Address.sendValue() instead of raw .transfer()

### DIFF
--- a/src/protocol/emissions/BaseEmissionsController.sol
+++ b/src/protocol/emissions/BaseEmissionsController.sol
@@ -5,6 +5,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 
 import { ITrust } from "src/interfaces/ITrust.sol";
 import { MetaERC20DispatchInit } from "src/interfaces/IMetaLayer.sol";
@@ -191,7 +192,7 @@ contract BaseEmissionsController is
             _finalityState
         );
         if (msg.value > gasLimit) {
-            payable(msg.sender).transfer(msg.value - gasLimit);
+            Address.sendValue(payable(msg.sender), msg.value - gasLimit);
         }
     }
 

--- a/src/protocol/emissions/SatelliteEmissionsController.sol
+++ b/src/protocol/emissions/SatelliteEmissionsController.sol
@@ -120,7 +120,7 @@ contract SatelliteEmissionsController is
         );
 
         if (msg.value > gasLimit) {
-            payable(msg.sender).transfer(msg.value - gasLimit);
+            Address.sendValue(payable(msg.sender), msg.value - gasLimit);
         }
     }
 
@@ -173,7 +173,7 @@ contract SatelliteEmissionsController is
         );
 
         if (msg.value > gasLimit) {
-            payable(msg.sender).transfer(msg.value - gasLimit);
+            Address.sendValue(payable(msg.sender), msg.value - gasLimit);
         }
     }
 }

--- a/tests/testnet/BaseSepoliaMinterAndBridge.sol
+++ b/tests/testnet/BaseSepoliaMinterAndBridge.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.29;
 
-import { console2 } from "forge-std/src/console2.sol";
 import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol";
 import { MetaERC20Dispatcher, FinalityState, IMetaERC20Hub } from "src/protocol/emissions/MetaERC20Dispatcher.sol";
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 
 interface IERC20 {
     function mint(address to, uint256 amount) external;
@@ -42,7 +42,7 @@ contract BaseSepoliaMinterAndBridge is MetaERC20Dispatcher, AccessControl {
         _bridgeTokens(metaERC20Hub, domain, bytes32(uint256(uint160(to))), amount, gasLimit, FinalityState.INSTANT);
 
         if (msg.value > gasLimit) {
-            payable(msg.sender).transfer(msg.value - gasLimit);
+            Address.sendValue(payable(msg.sender), msg.value - gasLimit);
         }
     }
 }


### PR DESCRIPTION
Note: I intentionally didn't import and use `Address.sendValue()` inside `WrappedTrust` token contract, in order for it to not be different from the standard WETH fork, but this could be changed if desired.