### PR TITLE
Feat: TrustBonding Emissions

### DIFF
--- a/src/interfaces/IBaseEmissionsController.sol
+++ b/src/interfaces/IBaseEmissionsController.sol
@@ -29,6 +29,7 @@ interface IBaseEmissionsController {
     error BaseEmissionsController_InsufficientGasPayment();
     error BaseEmissionsController_EpochMintingLimitExceeded();
     error BaseEmissionsController_InsufficientBurnableBalance();
+    error BaseEmissionsController_InvalidAddress();
 
     /* =================================================== */
     /*                      GETTERS                        */

--- a/src/interfaces/ICoreEmissionsController.sol
+++ b/src/interfaces/ICoreEmissionsController.sol
@@ -77,6 +77,9 @@ interface ICoreEmissionsController {
     /// @notice Thrown when emissions per epoch is zero
     error CoreEmissionsController_InvalidEmissionsPerEpoch();
 
+    /// @notice Thrown when epoch length is zero
+    error CoreEmissionsController_InvalidEpochLength();
+
     /* =================================================== */
     /*                      GETTERS                        */
     /* =================================================== */

--- a/src/interfaces/ICoreEmissionsController.sol
+++ b/src/interfaces/ICoreEmissionsController.sol
@@ -142,8 +142,10 @@ interface ICoreEmissionsController {
      */
     function getEmissionsAtEpoch(uint256 epochNumber) external view returns (uint256);
 
-    /// @notice Returns the number of TRUST tokens to be emitted at a given timestamp
-    /// @param timestamp The timestamp to query
-    /// @return The amount of TRUST tokens to emit at the timestamp
+    /**
+     * @notice Returns the number of TRUST tokens to be emitted at a given timestamp
+     * @param timestamp The timestamp to query
+     * @return The amount of TRUST tokens to emit at the timestamp
+     */
     function getEmissionsAtTimestamp(uint256 timestamp) external view returns (uint256);
 }

--- a/src/interfaces/ISatelliteEmissionsController.sol
+++ b/src/interfaces/ISatelliteEmissionsController.sol
@@ -71,4 +71,14 @@ interface ISatelliteEmissionsController {
      * @param epoch The epoch for which to bridge unclaimed rewards
      */
     function bridgeUnclaimedRewards(uint256 epoch) external payable;
+
+    /**
+     * @notice Calculates the amount of unclaimed rewards for a specific epoch.
+     * @dev Can be called by anyone to determine unclaimed rewards, but used specifically by the
+     * SatelliteEmissionsController to determine how much TRUST should be bridged back to the BaseEmissionsController
+     * and burned.
+     * @param epoch The epoch to calculate the unclaimed rewards for
+     * @return Amount of unclaimed rewards available for reclaiming
+     */
+    function getUnclaimedRewardsForEpoch(uint256 epoch) external view returns (uint256);
 }

--- a/src/interfaces/ITrustBonding.sol
+++ b/src/interfaces/ITrustBonding.sol
@@ -97,6 +97,13 @@ interface ITrustBonding {
         external;
 
     /**
+     * @notice Returns the total claimed rewards for a specific epoch
+     * @param epoch The epoch number
+     * @return The total amount of TRUST tokens claimed in the specified epoch
+     */
+    function totalClaimedRewardsForEpoch(uint256 epoch) external view returns (uint256);
+
+    /**
      * @notice Returns the length of an epoch in seconds
      * @return The epoch length in seconds
      */
@@ -206,16 +213,6 @@ interface ITrustBonding {
      * @return The personal utilization ratio for the user (scaled by 1e18)
      */
     function getPersonalUtilizationRatio(address _account, uint256 _epoch) external view returns (uint256);
-
-    /**
-     * @notice Calculates the amount of unclaimed rewards for a specific epoch.
-     * @dev Can be called by anyone to determine unclaimed rewards, but used specifically by the
-     * SatelliteEmissionsController to determine how much TRUST should be bridged back to the BaseEmissionsController
-     * and burned.
-     * @param epoch The epoch to calculate the unclaimed rewards for
-     * @return Amount of unclaimed rewards available for reclaiming
-     */
-    function getUnclaimedRewardsForEpoch(uint256 epoch) external view returns (uint256);
 
     /**
      * @notice Claims eligible Trust token rewards. Claims are always for the previous epoch (`currentEpoch() - 1`)

--- a/src/protocol/emissions/CoreEmissionsController.sol
+++ b/src/protocol/emissions/CoreEmissionsController.sol
@@ -14,6 +14,9 @@ contract CoreEmissionsController is ICoreEmissionsController {
     /// @dev Divisor for basis point calculations (100% = 10,000 basis points)
     uint256 internal constant BASIS_POINTS_DIVISOR = 10_000;
 
+    /// @dev Maximum allowed cliff duration in epochs
+    uint256 internal constant MAX_EMISSIONS_REDUCTION_CLIFF = 365;
+
     /// @dev Maximum allowed cliff reduction in basis points (10% = 1000 basis points)
     uint256 internal constant MAX_CLIFF_REDUCTION_BASIS_POINTS = 1000;
 
@@ -50,6 +53,7 @@ contract CoreEmissionsController is ICoreEmissionsController {
         internal
     {
         _validateTimestampStart(startTimestamp);
+        _validateEmissionsLength(emissionsLength);
         _validateEmissionsPerEpoch(emissionsPerEpoch);
         _validateCliff(emissionsReductionCliff);
         _validateReductionBasisPoints(emissionsReductionBasisPoints);
@@ -124,27 +128,33 @@ contract CoreEmissionsController is ICoreEmissionsController {
     /*                   VALIDATION                        */
     /* =================================================== */
 
-    function _validateEmissionsPerEpoch(uint256 emissionsPerEpoch) internal view {
-        if (emissionsPerEpoch == 0) {
-            revert CoreEmissionsController_InvalidEmissionsPerEpoch();
-        }
-    }
-
     function _validateTimestampStart(uint256 timestampStart) internal view {
         if (timestampStart < block.timestamp) {
             revert CoreEmissionsController_InvalidTimestampStart();
         }
     }
 
-    function _validateReductionBasisPoints(uint256 emissionsReductionBasisPoints) internal pure {
-        if (emissionsReductionBasisPoints > MAX_CLIFF_REDUCTION_BASIS_POINTS) {
-            revert CoreEmissionsController_InvalidReductionBasisPoints();
+    function _validateEmissionsLength(uint256 emissionsLength) internal pure {
+        if (emissionsLength == 0) {
+            revert CoreEmissionsController_InvalidEpochLength();
+        }
+    }
+
+    function _validateEmissionsPerEpoch(uint256 emissionsPerEpoch) internal view {
+        if (emissionsPerEpoch == 0) {
+            revert CoreEmissionsController_InvalidEmissionsPerEpoch();
         }
     }
 
     function _validateCliff(uint256 emissionsReductionCliff) internal pure {
-        if (emissionsReductionCliff == 0 || emissionsReductionCliff > 365) {
+        if (emissionsReductionCliff == 0 || emissionsReductionCliff > MAX_EMISSIONS_REDUCTION_CLIFF) {
             revert CoreEmissionsController_InvalidCliff();
+        }
+    }
+
+    function _validateReductionBasisPoints(uint256 emissionsReductionBasisPoints) internal pure {
+        if (emissionsReductionBasisPoints > MAX_CLIFF_REDUCTION_BASIS_POINTS) {
+            revert CoreEmissionsController_InvalidReductionBasisPoints();
         }
     }
 

--- a/src/protocol/emissions/MetaERC20Dispatcher.sol
+++ b/src/protocol/emissions/MetaERC20Dispatcher.sol
@@ -31,6 +31,16 @@ contract MetaERC20Dispatcher {
     event MetaERC20SpokeOrHubUpdated(address newMetaERC20SpokeOrHub);
 
     /* =================================================== */
+    /*                      ERRORS                         */
+    /* =================================================== */
+
+    error MetaERC20Dispatcher__InvalidAddress();
+
+    error MetaERC20Dispatcher__InvalidRecipientDomain();
+
+    error MetaERC20Dispatcher__InvalidGasCost();
+
+    /* =================================================== */
     /*                    INITIALIZER                      */
     /* =================================================== */
 
@@ -74,6 +84,9 @@ contract MetaERC20Dispatcher {
     /* =================================================== */
 
     function _setMessageGasCost(uint256 newGasCost) internal {
+        if (newGasCost == 0) {
+            revert MetaERC20Dispatcher__InvalidGasCost();
+        }
         _messageGasCost = newGasCost;
         emit MessageGasCostUpdated(newGasCost);
     }
@@ -84,11 +97,17 @@ contract MetaERC20Dispatcher {
     }
 
     function _setRecipientDomain(uint32 newDomain) internal {
+        if (newDomain == 0) {
+            revert MetaERC20Dispatcher__InvalidRecipientDomain();
+        }
         _recipientDomain = newDomain;
         emit RecipientDomainUpdated(newDomain);
     }
 
     function _setMetaERC20SpokeOrHub(address newMetaERC20SpokeOrHub) internal {
+        if (newMetaERC20SpokeOrHub == address(0)) {
+            revert MetaERC20Dispatcher__InvalidAddress();
+        }
         _metaERC20SpokeOrHub = newMetaERC20SpokeOrHub;
         emit MetaERC20SpokeOrHubUpdated(newMetaERC20SpokeOrHub);
     }

--- a/src/protocol/emissions/SatelliteEmissionsController.sol
+++ b/src/protocol/emissions/SatelliteEmissionsController.sol
@@ -65,6 +65,10 @@ contract SatelliteEmissionsController is
         external
         initializer
     {
+        if (admin == address(0) || trustBonding == address(0) || baseEmissionsController == address(0)) {
+            revert SatelliteEmissionsController_InvalidAddress();
+        }
+
         __AccessControl_init();
         __ReentrancyGuard_init();
 

--- a/src/protocol/emissions/TrustBonding.sol
+++ b/src/protocol/emissions/TrustBonding.sol
@@ -15,11 +15,6 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { VotingEscrow } from "src/external/curve/VotingEscrow.sol";
 
 /**
- * @dev Common forge commands for testing
- * forge inspect TrustBonding storage-layout
- */
-
-/**
  * @title  TrustBonding
  * @author 0xIntuition
  * @notice Core contract of the Intuition protocol. This contract manages the locking of TRUST tokens
@@ -275,28 +270,6 @@ contract TrustBonding is ITrustBonding, PausableUpgradeable, VotingEscrow {
         uint256 trustPerYear = _emissionsForEpoch(epoch) * epochsPerYear();
 
         return trustPerYear * BASIS_POINTS_DIVISOR / totalLockedAmount;
-    }
-
-    /// @inheritdoc ITrustBonding
-    function getUnclaimedRewardsForEpoch(uint256 epoch) external view returns (uint256) {
-        uint256 currentEpochLocal = currentEpoch();
-        // There cannot be any unclaimed rewards during the first two epochs, so we return 0.
-        if (currentEpochLocal < 2) {
-            return 0;
-        }
-
-        // We only want unclaimed rewards from epochs that are no longer claimable.
-        // For epochs that are still claimable, we return 0.
-        // This means we only consider epochs that are at least two epochs old.
-        if (epoch > currentEpochLocal - 2) {
-            return 0;
-        }
-
-        uint256 epochRewards = _emissionsForEpoch(epoch);
-        uint256 claimedRewards = totalClaimedRewardsForEpoch[epoch];
-        uint256 unclaimedRewards = epochRewards > claimedRewards ? epochRewards - claimedRewards : 0;
-
-        return unclaimedRewards;
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/protocol/emissions/TrustBonding.sol
+++ b/src/protocol/emissions/TrustBonding.sol
@@ -478,11 +478,19 @@ contract TrustBonding is ITrustBonding, PausableUpgradeable, VotingEscrow {
         // Fetch the target utilization for the previous epoch
         uint256 userUtilizationTarget = userClaimedRewardsForEpoch[_account][_epoch - 1];
 
-        // If there was no target utilization in the previous epoch, any increase in utilization is rewarded with the
-        // max ratio.
-        // Similarly, if the userUtilizationDelta is greater than the target, we also return the max ratio.
-        if (userUtilizationTarget == 0 || userUtilizationDelta >= userUtilizationTarget) {
-            return BASIS_POINTS_DIVISOR;
+        if (userUtilizationTarget == 0) {
+            // If the user had nothing claimable last epoch, don't penalize them as it's their first ever claim
+            if (_userEligibleRewardsForEpoch(_account, _epoch - 1) == 0) {
+                return BASIS_POINTS_DIVISOR; // 100%
+            }
+
+            // They did have eligibility last epoch but chose not to claim --> give them only the floor allocation
+            return personalUtilizationLowerBound;
+        }
+
+        // If the userUtilizationDelta is greater than the target, we also return the max ratio.
+        if (userUtilizationDelta >= userUtilizationTarget) {
+            return BASIS_POINTS_DIVISOR; // 100%
         }
 
         // Normalize the final utilizationRatio to be within the bounds of the personalUtilizationLowerBound and

--- a/tests/mocks/TrustBondingMock.sol
+++ b/tests/mocks/TrustBondingMock.sol
@@ -47,11 +47,4 @@ contract TrustBondingMock is TrustBonding {
     function setUserClaimedRewardsForEpoch(address user, uint256 epoch, uint256 amount) external {
         userClaimedRewardsForEpoch[user][epoch] = amount;
     }
-
-    /**
-     * @notice Helper function to set max claimable protocol fees for testing
-     */
-    function setMaxClaimableProtocolFeesForEpoch(uint256 epoch, uint256 amount) external {
-        maxClaimableProtocolFeesForEpoch[epoch] = amount;
-    }
 }

--- a/tests/unit/SatelliteEmissionsController/AccessControl.t.sol
+++ b/tests/unit/SatelliteEmissionsController/AccessControl.t.sol
@@ -7,6 +7,7 @@ import { BaseTest } from "tests/BaseTest.t.sol";
 import { ISatelliteEmissionsController } from "src/interfaces/ISatelliteEmissionsController.sol";
 import { SatelliteEmissionsController } from "src/protocol/emissions/SatelliteEmissionsController.sol";
 import { FinalityState } from "src/protocol/emissions/MetaERC20Dispatcher.sol";
+import { MetaERC20Dispatcher } from "src/protocol/emissions/MetaERC20Dispatcher.sol";
 
 /// @dev forge test --match-path 'tests/unit/SatelliteEmissionsController/AccessControl.t.sol'
 contract AccessControlTest is BaseTest {
@@ -60,17 +61,12 @@ contract AccessControlTest is BaseTest {
         protocol.satelliteEmissionsController.setMessageGasCost(newGasCost);
     }
 
-    function test_setMessageGasCost_shouldAllowZeroValue() external {
+    function test_setMessageGasCost_shouldRevertOnZeroValue() external {
         uint256 zeroGasCost = 0;
 
         resetPrank(users.admin);
+        vm.expectRevert(abi.encodeWithSelector(MetaERC20Dispatcher.MetaERC20Dispatcher__InvalidGasCost.selector));
         protocol.satelliteEmissionsController.setMessageGasCost(zeroGasCost);
-
-        assertEq(
-            protocol.satelliteEmissionsController.getMessageGasCost(),
-            zeroGasCost,
-            "Message gas cost should accept zero value"
-        );
     }
 
     function test_setMessageGasCost_shouldAllowLargeValue() external {
@@ -168,17 +164,12 @@ contract AccessControlTest is BaseTest {
         assertNotEq(originalSpokeOrHub, newSpokeOrHub, "Should be different from original");
     }
 
-    function test_setMetaERC20SpokeOrHub_shouldAllowZeroAddress() external {
+    function test_setMetaERC20SpokeOrHub_shouldRevertOnZeroAddress() external {
         address zeroAddress = address(0);
 
         resetPrank(users.admin);
+        vm.expectRevert(abi.encodeWithSelector(MetaERC20Dispatcher.MetaERC20Dispatcher__InvalidAddress.selector));
         protocol.satelliteEmissionsController.setMetaERC20SpokeOrHub(zeroAddress);
-
-        assertEq(
-            protocol.satelliteEmissionsController.getMetaERC20SpokeOrHub(),
-            zeroAddress,
-            "MetaERC20SpokeOrHub should accept zero address"
-        );
     }
 
     function test_setMetaERC20SpokeOrHub_shouldRevertWithUnauthorizedUser() external {
@@ -214,17 +205,14 @@ contract AccessControlTest is BaseTest {
         assertNotEq(originalDomain, newDomain, "Should be different from original");
     }
 
-    function test_setRecipientDomain_shouldAllowZeroValue() external {
+    function test_setRecipientDomain_shouldRevertOnZeroValue() external {
         uint32 zeroDomain = 0;
 
         resetPrank(users.admin);
-        protocol.satelliteEmissionsController.setRecipientDomain(zeroDomain);
-
-        assertEq(
-            protocol.satelliteEmissionsController.getRecipientDomain(),
-            zeroDomain,
-            "Recipient domain should accept zero value"
+        vm.expectRevert(
+            abi.encodeWithSelector(MetaERC20Dispatcher.MetaERC20Dispatcher__InvalidRecipientDomain.selector)
         );
+        protocol.satelliteEmissionsController.setRecipientDomain(zeroDomain);
     }
 
     function test_setRecipientDomain_shouldAllowMaxUint32() external {
@@ -373,7 +361,7 @@ contract AccessControlTest is BaseTest {
 
     function test_boundaryValues_messageGasCost() external {
         uint256[] memory testValues = new uint256[](3);
-        testValues[0] = 0; // Minimum
+        testValues[0] = 1; // Minimum
         testValues[1] = 1e18; // Large value
         testValues[2] = type(uint256).max; // Maximum
 
@@ -393,7 +381,7 @@ contract AccessControlTest is BaseTest {
 
     function test_boundaryValues_recipientDomain() external {
         uint32[] memory testValues = new uint32[](3);
-        testValues[0] = 0; // Minimum
+        testValues[0] = 1; // Minimum
         testValues[1] = 2_147_483_647; // Large value
         testValues[2] = type(uint32).max; // Maximum
 

--- a/tests/unit/SatelliteEmissionsController/BridgeUnclaimedRewards.t.sol
+++ b/tests/unit/SatelliteEmissionsController/BridgeUnclaimedRewards.t.sol
@@ -41,7 +41,7 @@ contract BridgeUnclaimedRewardsTest is TrustBondingBase {
         // Advance to epoch 4 so epoch 2 rewards are bridgeable (2 epochs old)
         _advanceToEpoch(4);
 
-        uint256 unclaimedRewardsBefore = protocol.trustBonding.getUnclaimedRewardsForEpoch(2);
+        uint256 unclaimedRewardsBefore = protocol.satelliteEmissionsController.getUnclaimedRewardsForEpoch(2);
         assertGt(unclaimedRewardsBefore, 0, "Should have unclaimed rewards to bridge");
 
         uint256 satelliteBalanceBefore = address(protocol.satelliteEmissionsController).balance;
@@ -71,7 +71,7 @@ contract BridgeUnclaimedRewardsTest is TrustBondingBase {
         // Advance to epoch 5 so epoch 3 rewards are bridgeable
         _advanceToEpoch(5);
 
-        uint256 unclaimedRewardsBefore = protocol.trustBonding.getUnclaimedRewardsForEpoch(3);
+        uint256 unclaimedRewardsBefore = protocol.satelliteEmissionsController.getUnclaimedRewardsForEpoch(3);
         assertGt(unclaimedRewardsBefore, 0, "Should have unclaimed rewards from Bob");
 
         uint256 satelliteBalanceBefore = address(protocol.satelliteEmissionsController).balance;
@@ -93,7 +93,7 @@ contract BridgeUnclaimedRewardsTest is TrustBondingBase {
         _advanceToEpoch(4);
 
         uint256 totalEpochRewards = protocol.trustBonding.trustPerEpoch(2);
-        uint256 unclaimedRewards = protocol.trustBonding.getUnclaimedRewardsForEpoch(2);
+        uint256 unclaimedRewards = protocol.satelliteEmissionsController.getUnclaimedRewardsForEpoch(2);
 
         assertEq(unclaimedRewards, totalEpochRewards, "All rewards should be unclaimed");
 
@@ -120,7 +120,7 @@ contract BridgeUnclaimedRewardsTest is TrustBondingBase {
         _advanceToEpoch(4);
 
         // Ensure there are unclaimed rewards to bridge
-        uint256 unclaimedRewards = protocol.trustBonding.getUnclaimedRewardsForEpoch(2);
+        uint256 unclaimedRewards = protocol.satelliteEmissionsController.getUnclaimedRewardsForEpoch(2);
         assertGt(unclaimedRewards, 0, "Should have unclaimed rewards");
 
         resetPrank(users.admin);
@@ -138,7 +138,7 @@ contract BridgeUnclaimedRewardsTest is TrustBondingBase {
         _advanceToEpoch(4);
 
         // Ensure there are unclaimed rewards to bridge
-        uint256 unclaimedRewards = protocol.trustBonding.getUnclaimedRewardsForEpoch(2);
+        uint256 unclaimedRewards = protocol.satelliteEmissionsController.getUnclaimedRewardsForEpoch(2);
         assertGt(unclaimedRewards, 0, "Should have unclaimed rewards");
 
         resetPrank(users.admin);
@@ -168,7 +168,7 @@ contract BridgeUnclaimedRewardsTest is TrustBondingBase {
         _advanceToEpoch(4);
 
         // Try to bridge epoch 3 rewards (only 1 epoch old, should fail)
-        uint256 unclaimedRewards = protocol.trustBonding.getUnclaimedRewardsForEpoch(3);
+        uint256 unclaimedRewards = protocol.satelliteEmissionsController.getUnclaimedRewardsForEpoch(3);
         assertEq(unclaimedRewards, 0, "Should have no bridgeable rewards for epoch 3 (too recent)");
 
         resetPrank(users.admin);
@@ -207,14 +207,14 @@ contract BridgeUnclaimedRewardsTest is TrustBondingBase {
         _advanceToEpoch(5);
 
         // Bridge epoch 2 rewards (should have Bob's unclaimed rewards)
-        uint256 unclaimedEpoch2 = protocol.trustBonding.getUnclaimedRewardsForEpoch(2);
+        uint256 unclaimedEpoch2 = protocol.satelliteEmissionsController.getUnclaimedRewardsForEpoch(2);
         assertGt(unclaimedEpoch2, 0, "Should have Bob's unclaimed epoch 2 rewards");
 
         resetPrank(users.admin);
         protocol.satelliteEmissionsController.bridgeUnclaimedRewards{ value: GAS_QUOTE }(2);
 
         // Bridge epoch 3 rewards (should have Bob's unclaimed rewards)
-        uint256 unclaimedEpoch3 = protocol.trustBonding.getUnclaimedRewardsForEpoch(3);
+        uint256 unclaimedEpoch3 = protocol.satelliteEmissionsController.getUnclaimedRewardsForEpoch(3);
         assertGt(unclaimedEpoch3, 0, "Should have Bob's unclaimed epoch 3 rewards");
 
         protocol.satelliteEmissionsController.bridgeUnclaimedRewards{ value: GAS_QUOTE }(3);
@@ -229,17 +229,17 @@ contract BridgeUnclaimedRewardsTest is TrustBondingBase {
         _createLock(users.alice, initialTokens);
 
         // In epoch 0: no rewards can be bridged
-        uint256 unclaimedEpoch0 = protocol.trustBonding.getUnclaimedRewardsForEpoch(0);
+        uint256 unclaimedEpoch0 = protocol.satelliteEmissionsController.getUnclaimedRewardsForEpoch(0);
         assertEq(unclaimedEpoch0, 0, "Epoch 0 should have no bridgeable rewards");
 
         // Advance to epoch 1: still no rewards can be bridged
         _advanceToEpoch(1);
-        uint256 unclaimedEpoch0InEpoch1 = protocol.trustBonding.getUnclaimedRewardsForEpoch(0);
+        uint256 unclaimedEpoch0InEpoch1 = protocol.satelliteEmissionsController.getUnclaimedRewardsForEpoch(0);
         assertEq(unclaimedEpoch0InEpoch1, 0, "Epoch 0 should have no bridgeable rewards in epoch 1");
 
         // Advance to epoch 2: the full emissions for epoch 0 are now bridgeable
         _advanceToEpoch(2);
-        uint256 unclaimedEpoch0InEpoch2 = protocol.trustBonding.getUnclaimedRewardsForEpoch(0);
+        uint256 unclaimedEpoch0InEpoch2 = protocol.satelliteEmissionsController.getUnclaimedRewardsForEpoch(0);
         assertEq(unclaimedEpoch0InEpoch2, 1_000_000 * 1e18, "Epoch 0 should now release the full 1,000,000 emissions");
     }
 
@@ -281,7 +281,7 @@ contract BridgeUnclaimedRewardsTest is TrustBondingBase {
         uint256 aliceClaimedRewards = protocol.trustBonding.userClaimedRewardsForEpoch(users.alice, 2);
         uint256 expectedUnclaimed = totalEpoch2Rewards - aliceClaimedRewards;
 
-        uint256 actualUnclaimed = protocol.trustBonding.getUnclaimedRewardsForEpoch(2);
+        uint256 actualUnclaimed = protocol.satelliteEmissionsController.getUnclaimedRewardsForEpoch(2);
         assertEq(actualUnclaimed, expectedUnclaimed, "Unclaimed should equal total minus Alice's claim");
 
         // Bridge the unclaimed rewards

--- a/tests/unit/SatelliteEmissionsController/BridgeUnclaimedRewards.t.sol
+++ b/tests/unit/SatelliteEmissionsController/BridgeUnclaimedRewards.t.sol
@@ -92,7 +92,7 @@ contract BridgeUnclaimedRewardsTest is TrustBondingBase {
         // Advance to epoch 4 so epoch 2 rewards are bridgeable
         _advanceToEpoch(4);
 
-        uint256 totalEpochRewards = protocol.trustBonding.trustPerEpoch(2);
+        uint256 totalEpochRewards = protocol.satelliteEmissionsController.getEmissionsAtEpoch(2);
         uint256 unclaimedRewards = protocol.satelliteEmissionsController.getUnclaimedRewardsForEpoch(2);
 
         assertEq(unclaimedRewards, totalEpochRewards, "All rewards should be unclaimed");
@@ -277,9 +277,9 @@ contract BridgeUnclaimedRewardsTest is TrustBondingBase {
         _advanceToEpoch(4);
 
         // Calculate expected unclaimed rewards (Bob + Charlie's rewards)
-        uint256 totalEpoch2Rewards = protocol.trustBonding.trustPerEpoch(2);
-        uint256 aliceClaimedRewards = protocol.trustBonding.userClaimedRewardsForEpoch(users.alice, 2);
-        uint256 expectedUnclaimed = totalEpoch2Rewards - aliceClaimedRewards;
+        uint256 totalEpoch2Rewards = protocol.satelliteEmissionsController.getEmissionsAtEpoch(2);
+        uint256 claimed = protocol.trustBonding.totalClaimedRewardsForEpoch(2);
+        uint256 expectedUnclaimed = totalEpoch2Rewards - claimed;
 
         uint256 actualUnclaimed = protocol.satelliteEmissionsController.getUnclaimedRewardsForEpoch(2);
         assertEq(actualUnclaimed, expectedUnclaimed, "Unclaimed should equal total minus Alice's claim");

--- a/tests/unit/TrustBonding/Reads.t.sol
+++ b/tests/unit/TrustBonding/Reads.t.sol
@@ -529,11 +529,6 @@ contract TrustBondingReadsTest is TrustBondingBase {
         assertGt(claimed, 0);
     }
 
-    function test_maxClaimableProtocolFeesForEpoch() external view {
-        uint256 fees = protocol.trustBonding.maxClaimableProtocolFeesForEpoch(0);
-        assertEq(fees, 0); // Should be 0 by default
-    }
-
     /* =================================================== */
     /*                   CONSTANTS                         */
     /* =================================================== */

--- a/tests/unit/TrustBonding/Reads.t.sol
+++ b/tests/unit/TrustBonding/Reads.t.sol
@@ -428,14 +428,14 @@ contract TrustBondingReadsTest is TrustBondingBase {
     /* =================================================== */
 
     function test_getUnclaimedRewards_epoch0() external view {
-        uint256 unclaimed = protocol.trustBonding.getUnclaimedRewardsForEpoch(0);
+        uint256 unclaimed = protocol.satelliteEmissionsController.getUnclaimedRewardsForEpoch(0);
         assertEq(unclaimed, 0); // No unclaimed rewards in epoch 0
     }
 
     function test_getUnclaimedRewards_epoch1() external {
         vm.warp(TRUST_BONDING_START_TIMESTAMP + TRUST_BONDING_EPOCH_LENGTH);
 
-        uint256 unclaimed = protocol.trustBonding.getUnclaimedRewardsForEpoch(1);
+        uint256 unclaimed = protocol.satelliteEmissionsController.getUnclaimedRewardsForEpoch(1);
         assertEq(unclaimed, 0); // No unclaimed rewards in epoch 1
     }
 
@@ -445,7 +445,7 @@ contract TrustBondingReadsTest is TrustBondingBase {
         // Advance multiple epochs without claiming
         vm.warp(TRUST_BONDING_START_TIMESTAMP + TRUST_BONDING_EPOCH_LENGTH * 3);
 
-        uint256 unclaimed = protocol.trustBonding.getUnclaimedRewardsForEpoch(1);
+        uint256 unclaimed = protocol.satelliteEmissionsController.getUnclaimedRewardsForEpoch(1);
         // Should have unclaimed rewards from epoch 1 (epoch 2 is still claimable)
         assertGt(unclaimed, 0);
     }
@@ -464,7 +464,7 @@ contract TrustBondingReadsTest is TrustBondingBase {
         // Move to epoch 3
         vm.warp(TRUST_BONDING_START_TIMESTAMP + TRUST_BONDING_EPOCH_LENGTH * 3);
 
-        uint256 unclaimed = protocol.trustBonding.getUnclaimedRewardsForEpoch(1);
+        uint256 unclaimed = protocol.satelliteEmissionsController.getUnclaimedRewardsForEpoch(1);
         // Should have Bob's unclaimed rewards from epoch 1
         assertGt(unclaimed, 0);
     }

--- a/tests/unit/TrustBonding/TrustBondingBase.t.sol
+++ b/tests/unit/TrustBonding/TrustBondingBase.t.sol
@@ -83,16 +83,16 @@ contract TrustBondingBase is BaseTest {
     /// @dev Set total claimed rewards for a specific epoch using vm.store
     function _setTotalClaimedRewardsForEpoch(uint256 epoch, uint256 claimedRewards) internal {
         // mapping(uint256 epoch => uint256 totalClaimedRewards) public totalClaimedRewardsForEpoch;
-        // Assuming this is at storage slot 13 based on the TrustBonding contract
-        bytes32 slot = keccak256(abi.encode(epoch, uint256(13)));
+        // Assuming this is at storage slot 12 based on the TrustBonding contract
+        bytes32 slot = keccak256(abi.encode(epoch, uint256(12)));
         vm.store(address(protocol.trustBonding), slot, bytes32(claimedRewards));
     }
 
     /// @dev Set user claimed rewards for a specific epoch using vm.store
     function _setUserClaimedRewardsForEpoch(address user, uint256 epoch, uint256 claimedRewards) internal {
         // mapping(address user => mapping(uint256 epoch => uint256 claimedRewards)) public userClaimedRewardsForEpoch;
-        // Assuming this is at storage slot 14 based on the TrustBonding contract
-        bytes32 userSlot = keccak256(abi.encode(user, uint256(14)));
+        // Assuming this is at storage slot 13 based on the TrustBonding contract
+        bytes32 userSlot = keccak256(abi.encode(user, uint256(13)));
         bytes32 finalSlot = keccak256(abi.encode(epoch, userSlot));
         vm.store(address(protocol.trustBonding), finalSlot, bytes32(claimedRewards));
     }


### PR DESCRIPTION
Summary of changes made:

- Fixed a bug inside `TrustBonding` to properly get the previous epoch number when calculating user's eligible rewards for it.
- Moved the unclaimed rewards calculation and checks to `SatelliteEmissionsController` in order to allow for the entire minted but unclaimed rewards amount to be burnable when bridged back on Base. Previously, this amount was scaled down by the current system utilization ratio.
- Removed unused variables from `TrustBonding`
- Added more validations and checks for invalid values inside `BaseEmissionsController` and `SatelliteEmissionsController` contracts.
- Added a change that prevents gaming the system via claim-skip-claim-skip-etc. scheme: users now get only the `personalUtilizationLowerBound` amount of rewards if they had rewards in previous epoch, but chose not to claim them
- Added more explicit underflow guards where applicable
- More descriptive error names and clarifications in the comments where applicable.
- Applied all relevant fixes to the tests after adding in the above changes.