### PR TITLE
Audit: Address remaining audit fixes from the 1st report

### DIFF
--- a/script/intuition/IntuitionDeployAndSetup.s.sol
+++ b/script/intuition/IntuitionDeployAndSetup.s.sol
@@ -277,7 +277,6 @@ contract IntuitionDeployAndSetup is SetupScript {
             IAccessControl(address(multiVault)).grantRole(MIGRATOR_ROLE, MIGRATOR);
             console2.log("MIGRATOR_ROLE granted to:", MIGRATOR);
         }
-
     }
 
     function _prepareMultiVaultInitData() internal {

--- a/src/interfaces/ISatelliteEmissionsController.sol
+++ b/src/interfaces/ISatelliteEmissionsController.sol
@@ -50,6 +50,7 @@ interface ISatelliteEmissionsController {
     error SatelliteEmissionsController_PreviouslyBridgedUnclaimedEmissions();
     error SatelliteEmissionsController_InsufficientBalance();
     error SatelliteEmissionsController_InsufficientGasPayment();
+    error SatelliteEmissionsController_TrustBondingNotSet();
 
     /* =================================================== */
     /*                      GETTERS                        */

--- a/src/protocol/emissions/SatelliteEmissionsController.sol
+++ b/src/protocol/emissions/SatelliteEmissionsController.sol
@@ -175,6 +175,10 @@ contract SatelliteEmissionsController is
 
     /// @inheritdoc ISatelliteEmissionsController
     function bridgeUnclaimedEmissions(uint256 epoch) external payable onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (_TRUST_BONDING == address(0)) {
+            revert SatelliteEmissionsController_TrustBondingNotSet();
+        }
+
         // Prevent bridging of zero amount if no unclaimed rewards are available.
         uint256 amount = ITrustBonding(_TRUST_BONDING).getUnclaimedRewardsForEpoch(epoch);
         if (amount == 0) {

--- a/src/protocol/emissions/TrustBonding.sol
+++ b/src/protocol/emissions/TrustBonding.sol
@@ -237,8 +237,9 @@ contract TrustBonding is ITrustBonding, PausableUpgradeable, VotingEscrow {
 
         uint256 userRewards;
         uint256 personalUtilization;
+
         if (_currEpoch > 0) {
-            uint256 prevEpoch = _previousEpoch(_currEpoch);
+            uint256 prevEpoch = _currEpoch - 1;
             userRewards = _userEligibleRewardsForEpoch(account, prevEpoch);
             personalUtilization = _getPersonalUtilizationRatio(account, prevEpoch);
         }
@@ -276,13 +277,16 @@ contract TrustBonding is ITrustBonding, PausableUpgradeable, VotingEscrow {
         if (_currEpoch == 0) {
             return 0;
         }
-        uint256 prevEpoch = _previousEpoch(_currEpoch);
+
+        uint256 prevEpoch = _currEpoch - 1;
         uint256 userClaimedReward = userClaimedRewardsForEpoch[account][prevEpoch];
         uint256 userEligibleReward = _userEligibleRewardsForEpoch(account, prevEpoch)
             * _getPersonalUtilizationRatio(account, prevEpoch) / BASIS_POINTS_DIVISOR;
+
         if (userEligibleReward <= userClaimedReward) {
             return 0;
         }
+
         return userEligibleReward - userClaimedReward;
     }
 
@@ -650,9 +654,5 @@ contract TrustBonding is ITrustBonding, PausableUpgradeable, VotingEscrow {
     function _previousEpoch() internal view returns (uint256) {
         uint256 curr = _currentEpoch();
         return curr == 0 ? 0 : curr - 1;
-    }
-
-    function _previousEpoch(uint256 _currEpoch) internal pure returns (uint256) {
-        return _currEpoch == 0 ? 0 : _currEpoch - 1;
     }
 }

--- a/tests/unit/SatelliteEmissionsController/AccessControl.t.sol
+++ b/tests/unit/SatelliteEmissionsController/AccessControl.t.sol
@@ -3,29 +3,15 @@ pragma solidity 0.8.29;
 
 import { console, Vm } from "forge-std/src/Test.sol";
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
-import { BaseTest } from "tests/BaseTest.t.sol";
+import { TrustBondingBase } from "tests/unit/TrustBonding/TrustBondingBase.t.sol";
 import { ISatelliteEmissionsController } from "src/interfaces/ISatelliteEmissionsController.sol";
 import { SatelliteEmissionsController } from "src/protocol/emissions/SatelliteEmissionsController.sol";
 import { MetaERC20Dispatcher } from "src/protocol/emissions/MetaERC20Dispatcher.sol";
 import { MetaERC20DispatchInit, FinalityState } from "src/interfaces/IMetaLayer.sol";
-import { CoreEmissionsControllerInit } from "src/interfaces/ICoreEmissionsController.sol";
 import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 /// @dev forge test --match-path 'tests/unit/SatelliteEmissionsController/AccessControl.t.sol'
-contract AccessControlTest is BaseTest {
-    // Test constants
-    uint256 internal constant TEST_START_TIMESTAMP = 1_640_995_200; // Jan 1, 2022
-    uint256 internal constant TEST_EPOCH_LENGTH = 14 days;
-    uint256 internal constant TEST_EMISSIONS_PER_EPOCH = 1_000_000 * 1e18;
-    uint256 internal constant TEST_REDUCTION_CLIFF = 26;
-    uint256 internal constant TEST_REDUCTION_BASIS_POINTS = 1000; // 10%
-    uint32 internal constant TEST_RECIPIENT_DOMAIN = 1;
-    uint256 internal constant TEST_GAS_LIMIT = 125_000;
-
-    // Initializer structs
-    MetaERC20DispatchInit public metaERC20DispatchInit;
-    CoreEmissionsControllerInit public coreEmissionsInit;
-
+contract AccessControlTest is TrustBondingBase {
     /// @notice Test addresses
     address public unauthorizedUser = address(0x999);
     address public baseEmissionsController = address(0xABC);
@@ -44,38 +30,6 @@ contract AccessControlTest is BaseTest {
     function setUp() public override {
         super.setUp();
         vm.deal(unauthorizedUser, 1 ether);
-    }
-
-    function _deploySatelliteEmissionsController() internal returns (SatelliteEmissionsController) {
-        // Deploy SatelliteEmissionsController implementation
-        SatelliteEmissionsController satelliteEmissionsControllerImpl = new SatelliteEmissionsController();
-
-        // Deploy proxy
-        TransparentUpgradeableProxy satelliteEmissionsControllerProxyContract =
-            new TransparentUpgradeableProxy(address(satelliteEmissionsControllerImpl), users.admin, "");
-
-        SatelliteEmissionsController satelliteEmissionsController =
-            SatelliteEmissionsController(payable(address(satelliteEmissionsControllerProxyContract)));
-
-        // Initialize the contract
-        metaERC20DispatchInit = MetaERC20DispatchInit({
-            hubOrSpoke: address(0x123), // Mock meta spoke
-            recipientDomain: TEST_RECIPIENT_DOMAIN,
-            gasLimit: TEST_GAS_LIMIT,
-            finalityState: FinalityState.INSTANT
-        });
-
-        coreEmissionsInit = CoreEmissionsControllerInit({
-            startTimestamp: TEST_START_TIMESTAMP,
-            emissionsLength: TEST_EPOCH_LENGTH,
-            emissionsPerEpoch: TEST_EMISSIONS_PER_EPOCH,
-            emissionsReductionCliff: TEST_REDUCTION_CLIFF,
-            emissionsReductionBasisPoints: TEST_REDUCTION_BASIS_POINTS
-        });
-
-        vm.label(address(satelliteEmissionsController), "SatelliteEmissionsController");
-
-        return satelliteEmissionsController;
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/tests/unit/SatelliteEmissionsController/BridgeUnclaimedEmissions.t.sol
+++ b/tests/unit/SatelliteEmissionsController/BridgeUnclaimedEmissions.t.sol
@@ -115,6 +115,34 @@ contract BridgeUnclaimedEmissionsTest is TrustBondingBase {
     /*//////////////////////////////////////////////////////////////
                         FAILED BRIDGING TESTS
     //////////////////////////////////////////////////////////////*/
+
+    function test_bridgeUnclaimedEmissions_revertWhen_trustBondingIsNotSetYet() external {
+        // Deploy a new SatelliteEmissionsController without setting TrustBonding
+        SatelliteEmissionsController newSatelliteEmissionsController = _deploySatelliteEmissionsController();
+
+        address baseEmissionsController = address(0xABC);
+
+        // Initialize the new SatelliteEmissionsController
+        newSatelliteEmissionsController.initialize(
+            users.admin,
+            baseEmissionsController, // placeholder address for BaseEmissionsController
+            metaERC20DispatchInit,
+            coreEmissionsInit
+        );
+
+        // Advance to epoch 4 to ensure there are bridgeable rewards
+        _createLock(users.alice, initialTokens);
+        _advanceToEpoch(4);
+
+        resetPrank(users.admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ISatelliteEmissionsController.SatelliteEmissionsController_TrustBondingNotSet.selector
+            )
+        );
+        newSatelliteEmissionsController.bridgeUnclaimedEmissions{ value: GAS_QUOTE }(2);
+    }
+
     function test_bridgeUnclaimedEmissions_revertWhen_previouslyClaimed() external {
         _createLock(users.alice, initialTokens);
         _advanceToEpoch(4);


### PR DESCRIPTION
### Summary of changes made:

5.1 Replaced helper with direct math: removed `_previousEpoch(uint256)` overload and now use `prevEpoch = currentEpochLocal - 1` after existing `> 0` checks in `getUserCurrentClaimableRewards`, and `getUserInfo` as it's simpler (due to avoiding the use of an overloaded function), and there is no underflow risk.

5.2 Added a zero address check in `SatelliteEmissionsController.bridgeUnclaimedEmissions` (revert if `TrustBonding` not set yet), analogous to how the `BaseEmissionsController.mintAndBridge` already checks that `SatelliteEmissionsController` address is non-zero. This PR also includes the tests to demonstrate this behavior.