### PR TITLE
Fixes for issues S-112 & S-595: Boundary-exclusive epoch accounting and reward-budget guardrails

### DIFF
--- a/script/base/DeployBaseUpgradeImplementations.s.sol
+++ b/script/base/DeployBaseUpgradeImplementations.s.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.29;
+
+import { console2 } from "forge-std/src/console2.sol";
+
+import {
+    ITransparentUpgradeableProxy
+} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import { SetupScript } from "script/SetupScript.s.sol";
+import { BaseEmissionsController } from "src/protocol/emissions/BaseEmissionsController.sol";
+
+/*
+MAINNET (Base)
+forge script script/base/DeployBaseUpgradeImplementations.s.sol:DeployBaseUpgradeImplementations \
+--optimizer-runs 10000 \
+--rpc-url base \
+--broadcast \
+--slow \
+--verify \
+--verifier etherscan \
+--verifier-url "https://api.etherscan.io/v2/api?chainid=8453" \
+--chain 8453 \
+--etherscan-api-key $ETHERSCAN_API_KEY
+*/
+
+contract DeployBaseUpgradeImplementations is SetupScript {
+    error UnsupportedChain();
+
+    /// @dev Mainnet proxy addresses (Base, chain 8453)
+    address internal constant BASE_EC_PROXY = 0x7745bDEe668501E5eeF7e9605C746f9cDfb60667;
+    address internal constant BASE_EC_PROXY_ADMIN = 0x58dCdf3b6F5D03835CF6556EdC798bfd690B251a;
+
+    BaseEmissionsController public baseEmissionsControllerImplementation;
+
+    function setUp() public override {
+        super.setUp();
+
+        if (block.chainid != NETWORK_BASE) {
+            revert UnsupportedChain();
+        }
+    }
+
+    function run() public broadcast {
+        console2.log("");
+        console2.log("DEPLOYMENTS: =+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+");
+
+        _deployImplementations();
+
+        console2.log("");
+        console2.log("DEPLOYMENT COMPLETE: =+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+");
+        contractInfo("BaseEmissionsController Implementation", address(baseEmissionsControllerImplementation));
+
+        _logUpgradeCalldata();
+    }
+
+    function _deployImplementations() internal {
+        baseEmissionsControllerImplementation = new BaseEmissionsController();
+        info("BaseEmissionsController Implementation", address(baseEmissionsControllerImplementation));
+    }
+
+    /// @dev Logs the encoded calldata for the timelock-scheduled upgrade operation.
+    ///      Use this as the `data` parameter when calling TimelockController.schedule().
+    function _logUpgradeCalldata() internal view {
+        console2.log("");
+        console2.log("UPGRADE CALLDATA: =+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+");
+
+        console2.log("");
+        console2.log("BaseEmissionsController upgrade (target: ProxyAdmin %s):", BASE_EC_PROXY_ADMIN);
+        console2.logBytes(
+            abi.encodeCall(
+                ProxyAdmin.upgradeAndCall,
+                (ITransparentUpgradeableProxy(BASE_EC_PROXY), address(baseEmissionsControllerImplementation), "")
+            )
+        );
+    }
+}

--- a/script/intuition/DeployCoreUpgradeImplementations.s.sol
+++ b/script/intuition/DeployCoreUpgradeImplementations.s.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.29;
+
+import { console2 } from "forge-std/src/console2.sol";
+
+import {
+    ITransparentUpgradeableProxy
+} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import { SetupScript } from "script/SetupScript.s.sol";
+import { MultiVault } from "src/protocol/MultiVault.sol";
+import { TrustBonding } from "src/protocol/emissions/TrustBonding.sol";
+import { OffsetProgressiveCurve } from "src/protocol/curves/OffsetProgressiveCurve.sol";
+import { AtomWallet } from "src/protocol/wallet/AtomWallet.sol";
+import { SatelliteEmissionsController } from "src/protocol/emissions/SatelliteEmissionsController.sol";
+
+/*
+MAINNET (Intuition)
+forge script script/intuition/DeployCoreUpgradeImplementations.s.sol:DeployCoreUpgradeImplementations \
+--optimizer-runs 10000 \
+--rpc-url intuition \
+--broadcast \
+--slow \
+--verify \
+--chain 1155 \
+--verifier blockscout \
+--verifier-url 'https://intuition.calderaexplorer.xyz/api/'
+*/
+
+contract DeployCoreUpgradeImplementations is SetupScript {
+    error UnsupportedChain();
+
+    /// @dev Mainnet proxy addresses (Intuition, chain 1155)
+    address internal constant MULTIVAULT_PROXY = 0x6E35cF57A41fA15eA0EaE9C33e751b01A784Fe7e;
+    address internal constant MULTIVAULT_PROXY_ADMIN = 0x1999faD6477e4fa9aA0FF20DaafC32F7B90005C8;
+    address internal constant TRUST_BONDING_PROXY = 0x635bBD1367B66E7B16a21D6E5A63C812fFC00617;
+    address internal constant TRUST_BONDING_PROXY_ADMIN = 0xF10FEE90B3C633c4fCd49aA557Ec7d51E5AEef62;
+    address internal constant OFFSET_CURVE_PROXY = 0x23afF95153aa88D28B9B97Ba97629E05D5fD335d;
+    address internal constant OFFSET_CURVE_PROXY_ADMIN = 0xe58B117aDfB0a141dC1CC22b98297294F6E2c5E7;
+    address internal constant ATOM_WALLET_BEACON = 0xC23cD55CF924b3FE4b97deAA0EAF222a5082A1FF;
+    address internal constant SATELLITE_EC_PROXY = 0x73B8819f9b157BE42172E3866fB0Ba0d5fA0A5c6;
+    address internal constant SATELLITE_EC_PROXY_ADMIN = 0xdF60D18E86F3454309aD7734055843F7ee5f30a3;
+
+    MultiVault public multiVaultImplementation;
+    TrustBonding public trustBondingImplementation;
+    OffsetProgressiveCurve public offsetProgressiveCurveImplementation;
+    AtomWallet public atomWalletImpl;
+    SatelliteEmissionsController public satelliteEmissionsControllerImplementation;
+
+    function setUp() public override {
+        super.setUp();
+
+        if (block.chainid != NETWORK_INTUITION) {
+            revert UnsupportedChain();
+        }
+    }
+
+    function run() public broadcast {
+        console2.log("");
+        console2.log("DEPLOYMENTS: =+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+");
+
+        _deployImplementations();
+
+        console2.log("");
+        console2.log("DEPLOYMENT COMPLETE: =+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+");
+        contractInfo("MultiVault Implementation", address(multiVaultImplementation));
+        contractInfo("TrustBonding Implementation", address(trustBondingImplementation));
+        contractInfo("OffsetProgressiveCurve Implementation", address(offsetProgressiveCurveImplementation));
+        contractInfo("AtomWallet Implementation", address(atomWalletImpl));
+        contractInfo("SatelliteEmissionsController Implementation", address(satelliteEmissionsControllerImplementation));
+
+        _logUpgradeCalldata();
+    }
+
+    function _deployImplementations() internal {
+        multiVaultImplementation = new MultiVault();
+        info("MultiVault Implementation", address(multiVaultImplementation));
+
+        trustBondingImplementation = new TrustBonding();
+        info("TrustBonding Implementation", address(trustBondingImplementation));
+
+        offsetProgressiveCurveImplementation = new OffsetProgressiveCurve();
+        info("OffsetProgressiveCurve Implementation", address(offsetProgressiveCurveImplementation));
+
+        atomWalletImpl = new AtomWallet();
+        info("AtomWallet Implementation", address(atomWalletImpl));
+
+        satelliteEmissionsControllerImplementation = new SatelliteEmissionsController();
+        info("SatelliteEmissionsController Implementation", address(satelliteEmissionsControllerImplementation));
+    }
+
+    /// @dev Logs the encoded calldata for each timelock-scheduled upgrade operation.
+    ///      Use these as the `data` parameter when calling TimelockController.schedule().
+    function _logUpgradeCalldata() internal view {
+        console2.log("");
+        console2.log("UPGRADE CALLDATA: =+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+");
+
+        // ProxyAdmin.upgradeAndCall(proxy, newImpl, 0x) for each TransparentUpgradeableProxy
+        console2.log("");
+        console2.log("MultiVault upgrade (target: ProxyAdmin %s):", MULTIVAULT_PROXY_ADMIN);
+        console2.logBytes(
+            abi.encodeCall(
+                ProxyAdmin.upgradeAndCall,
+                (ITransparentUpgradeableProxy(MULTIVAULT_PROXY), address(multiVaultImplementation), "")
+            )
+        );
+
+        console2.log("");
+        console2.log("TrustBonding upgrade (target: ProxyAdmin %s):", TRUST_BONDING_PROXY_ADMIN);
+        console2.logBytes(
+            abi.encodeCall(
+                ProxyAdmin.upgradeAndCall,
+                (ITransparentUpgradeableProxy(TRUST_BONDING_PROXY), address(trustBondingImplementation), "")
+            )
+        );
+
+        console2.log("");
+        console2.log("OffsetProgressiveCurve upgrade (target: ProxyAdmin %s):", OFFSET_CURVE_PROXY_ADMIN);
+        console2.logBytes(
+            abi.encodeCall(
+                ProxyAdmin.upgradeAndCall,
+                (ITransparentUpgradeableProxy(OFFSET_CURVE_PROXY), address(offsetProgressiveCurveImplementation), "")
+            )
+        );
+
+        console2.log("");
+        console2.log("SatelliteEmissionsController upgrade (target: ProxyAdmin %s):", SATELLITE_EC_PROXY_ADMIN);
+        console2.logBytes(
+            abi.encodeCall(
+                ProxyAdmin.upgradeAndCall,
+                (
+                    ITransparentUpgradeableProxy(SATELLITE_EC_PROXY),
+                    address(satelliteEmissionsControllerImplementation),
+                    ""
+                )
+            )
+        );
+
+        // UpgradeableBeacon.upgradeTo(newImpl) for AtomWalletBeacon
+        console2.log("");
+        console2.log("AtomWallet beacon upgrade (target: Beacon %s):", ATOM_WALLET_BEACON);
+        console2.logBytes(abi.encodeCall(UpgradeableBeacon.upgradeTo, (address(atomWalletImpl))));
+    }
+}

--- a/src/interfaces/ITrustBonding.sol
+++ b/src/interfaces/ITrustBonding.sol
@@ -71,6 +71,9 @@ interface ITrustBonding {
     /// @dev Thrown when an invalid utilization lower bound is provided (must be between 0 and 1e18)
     error TrustBonding_InvalidUtilizationLowerBound();
 
+    /// @dev Thrown when the epoch budget is fully exhausted and no more rewards can be claimed
+    error TrustBonding_EpochBudgetExhausted();
+
     /// @dev Thrown when an invalid start timestamp is provided during initialization
     error TrustBonding_InvalidStartTimestamp();
 

--- a/src/protocol/emissions/CoreEmissionsController.sol
+++ b/src/protocol/emissions/CoreEmissionsController.sol
@@ -175,8 +175,13 @@ contract CoreEmissionsController is ICoreEmissionsController {
         return _START_TIMESTAMP + (epoch * _EPOCH_LENGTH);
     }
 
+    /// @dev Returns the last second that belongs to `epoch`.
+    ///      Epochs are closed intervals [start, end] with no overlap:
+    ///      epoch N ends at `start + (N+1)*length - 1`, epoch N+1 starts
+    ///      at `start + (N+1)*length`.  This eliminates the boundary
+    ///      ambiguity where a single timestamp could belong to two epochs.
     function _calculateEpochTimestampEnd(uint256 epoch) internal view returns (uint256) {
-        return _START_TIMESTAMP + (epoch * _EPOCH_LENGTH) + _EPOCH_LENGTH;
+        return _START_TIMESTAMP + (epoch * _EPOCH_LENGTH) + _EPOCH_LENGTH - 1;
     }
 
     /**

--- a/src/protocol/emissions/TrustBonding.sol
+++ b/src/protocol/emissions/TrustBonding.sol
@@ -112,6 +112,10 @@ contract TrustBonding is ITrustBonding, PausableUpgradeable, VotingEscrow {
         _disableInitializers();
     }
 
+    /*//////////////////////////////////////////////////////////////
+                             INITIALIZER
+    //////////////////////////////////////////////////////////////*/
+
     /// @inheritdoc ITrustBonding
     function initialize(
         address _owner,
@@ -380,6 +384,17 @@ contract TrustBonding is ITrustBonding, PausableUpgradeable, VotingEscrow {
         // Check if the user has already claimed rewards for the previous epoch
         if (_hasClaimedRewardsForEpoch(msg.sender, prevEpoch)) {
             revert TrustBonding_RewardsAlreadyClaimedForEpoch();
+        }
+
+        // Enforce per-epoch budget safety to keep total claimed rewards bounded by epoch emissions.
+        uint256 epochBudget = _emissionsForEpoch(prevEpoch);
+        uint256 alreadyClaimed = totalClaimedRewardsForEpoch[prevEpoch];
+        if (alreadyClaimed >= epochBudget) {
+            revert TrustBonding_EpochBudgetExhausted();
+        }
+        uint256 remainingBudget = epochBudget - alreadyClaimed;
+        if (userRewards > remainingBudget) {
+            userRewards = remainingBudget;
         }
 
         // Increment the total claimed inflationary rewards for the previous epoch and set the user's claimed rewards

--- a/tests/unit/BaseEmissionsController/Reads.t.sol
+++ b/tests/unit/BaseEmissionsController/Reads.t.sol
@@ -188,12 +188,12 @@ contract BaseEmissionsControllerGettersTest is BaseTest {
 
     function test_getEpochTimestampEnd_EpochZero_Success() public {
         uint256 endTimestamp = baseEmissionsController.getEpochTimestampEnd(0);
-        assertEq(endTimestamp, TEST_START_TIMESTAMP + TEST_EPOCH_LENGTH);
+        assertEq(endTimestamp, TEST_START_TIMESTAMP + TEST_EPOCH_LENGTH - 1);
     }
 
     function test_getEpochTimestampEnd_EpochOne_Success() public {
         uint256 endTimestamp = baseEmissionsController.getEpochTimestampEnd(1);
-        assertEq(endTimestamp, TEST_START_TIMESTAMP + (2 * TEST_EPOCH_LENGTH));
+        assertEq(endTimestamp, TEST_START_TIMESTAMP + (2 * TEST_EPOCH_LENGTH) - 1);
     }
 
     function test_getCurrentEpochTimestampStart_Success() public {

--- a/tests/unit/CoreEmissionsController/Reads.t.sol
+++ b/tests/unit/CoreEmissionsController/Reads.t.sol
@@ -104,14 +104,14 @@ contract CoreEmissionsControllerTest is CoreEmissionsControllerBase {
         _initializeController();
 
         uint256 endTimestamp = controller.getEpochTimestampEnd(0);
-        assertEq(endTimestamp, DEFAULT_START_TIMESTAMP + DEFAULT_EPOCH_LENGTH);
+        assertEq(endTimestamp, DEFAULT_START_TIMESTAMP + DEFAULT_EPOCH_LENGTH - 1);
     }
 
     function test_getEpochTimestampEnd_EpochOne_Success() public {
         _initializeController();
 
         uint256 endTimestamp = controller.getEpochTimestampEnd(1);
-        assertEq(endTimestamp, DEFAULT_START_TIMESTAMP + (2 * DEFAULT_EPOCH_LENGTH));
+        assertEq(endTimestamp, DEFAULT_START_TIMESTAMP + (2 * DEFAULT_EPOCH_LENGTH) - 1);
     }
 
     /* =================================================== */

--- a/tests/unit/SatelliteEmissionsController/Reads.t.sol
+++ b/tests/unit/SatelliteEmissionsController/Reads.t.sol
@@ -169,7 +169,7 @@ contract SatelliteEmissionsControllerGettersTest is BaseTest {
 
     function test_getEpochTimestampEnd_EpochZero_Success() public {
         uint256 endTimestamp = satelliteEmissionsController.getEpochTimestampEnd(0);
-        assertEq(endTimestamp, TEST_START_TIMESTAMP + TEST_EPOCH_LENGTH);
+        assertEq(endTimestamp, TEST_START_TIMESTAMP + TEST_EPOCH_LENGTH - 1);
     }
 
     function test_getCurrentEpochTimestampStart_Success() public {

--- a/tests/unit/TrustBonding/BoundaryAccounting.t.sol
+++ b/tests/unit/TrustBonding/BoundaryAccounting.t.sol
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.29;
+
+import { ITrustBonding } from "src/interfaces/ITrustBonding.sol";
+import { ICoreEmissionsController } from "src/interfaces/ICoreEmissionsController.sol";
+import { TrustBondingBase } from "tests/unit/TrustBonding/TrustBondingBase.t.sol";
+
+contract BoundaryAccountingTest is TrustBondingBase {
+    event RewardsClaimed(address indexed user, address indexed recipient, uint256 amount);
+
+    function setUp() public override {
+        super.setUp();
+        vm.deal(address(protocol.satelliteEmissionsController), 10_000_000 ether);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    EPOCH BOUNDARY TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice CoreEmissionsController now returns epochTimestampEnd(N) as the last second
+    ///         of epoch N (closed interval [start, end]). A lock at epochTimestampEnd(N)
+    ///         is a legitimate epoch-N action and MUST be included in the epoch-N snapshot.
+    function test_totalBondedBalanceAtEpochEnd_includesLockAtEpochEnd() external {
+        _createLock(users.alice, initialTokens);
+
+        uint256 targetEpoch = 0;
+        uint256 epochEnd = protocol.trustBonding.epochTimestampEnd(targetEpoch);
+
+        vm.warp(epochEnd);
+        uint256 totalBefore = protocol.trustBonding.totalBondedBalanceAtEpochEnd(targetEpoch);
+
+        _createLock(users.bob, initialTokens);
+
+        uint256 bobBalanceAtEpochEnd = protocol.trustBonding.userBondedBalanceAtEpochEnd(users.bob, targetEpoch);
+        uint256 totalAfter = protocol.trustBonding.totalBondedBalanceAtEpochEnd(targetEpoch);
+
+        assertGt(bobBalanceAtEpochEnd, 0, "lock at epoch end must be included (legitimate participation)");
+        assertGt(totalAfter, totalBefore, "total must increase for epoch-end lock");
+    }
+
+    /// @notice S-112 core protection: a lock at epochTimestampEnd(N) + 1 is the first second
+    ///         of epoch N+1 and must NOT be included in epoch N's reward snapshot.
+    function test_totalBondedBalanceAtEpochEnd_excludesNextEpochStartLock() external {
+        _createLock(users.alice, initialTokens);
+
+        uint256 targetEpoch = 0;
+        uint256 nextEpochStart = protocol.trustBonding.epochTimestampEnd(targetEpoch) + 1;
+
+        vm.warp(nextEpochStart);
+        uint256 totalBefore = protocol.trustBonding.totalBondedBalanceAtEpochEnd(targetEpoch);
+
+        _createLock(users.bob, initialTokens);
+
+        uint256 bobBalanceAtEpochEnd = protocol.trustBonding.userBondedBalanceAtEpochEnd(users.bob, targetEpoch);
+        uint256 bobRewardsAtEpochEnd = protocol.trustBonding.userEligibleRewardsForEpoch(users.bob, targetEpoch);
+        uint256 totalAfter = protocol.trustBonding.totalBondedBalanceAtEpochEnd(targetEpoch);
+
+        assertEq(bobBalanceAtEpochEnd, 0, "next-epoch-start lock must be excluded from closed epoch");
+        assertEq(bobRewardsAtEpochEnd, 0, "next-epoch-start lock must have no prior-epoch rewards");
+        assertEq(totalAfter, totalBefore, "total must remain immutable after epoch end");
+    }
+
+    /// @notice Verify that epochTimestampEnd(N) + 1 == epochTimestampStart(N+1),
+    ///         proving no timestamp overlap between adjacent epochs.
+    function test_epochBoundaries_noOverlap() external view {
+        ICoreEmissionsController controller =
+            ICoreEmissionsController(protocol.trustBonding.satelliteEmissionsController());
+
+        for (uint256 epoch = 0; epoch < 5; epoch++) {
+            uint256 epochEnd = controller.getEpochTimestampEnd(epoch);
+            uint256 nextEpochStart = controller.getEpochTimestampStart(epoch + 1);
+            assertEq(epochEnd + 1, nextEpochStart, "epoch boundaries must be contiguous with no overlap");
+
+            // Boundary timestamp belongs to current epoch
+            assertEq(controller.getEpochAtTimestamp(epochEnd), epoch, "epoch end must belong to current epoch");
+            assertEq(controller.getEpochAtTimestamp(epochEnd + 1), epoch + 1, "epochEnd+1 must belong to next epoch");
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    BUDGET GUARDRAIL TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_claimRewards_clampsToRemainingBudget_whenRemainingIsLessThanUserRewards() external {
+        _createLock(users.alice, initialTokens);
+        _advanceToEpoch(1);
+
+        uint256 previousEpoch = 0;
+        uint256 userRewardsWithoutCap = protocol.trustBonding.userEligibleRewardsForEpoch(users.alice, previousEpoch);
+
+        // Assert the user's eligible reward exceeds the remaining budget (1 wei),
+        // proving the clamp will actually reduce the payout.
+        assertGt(userRewardsWithoutCap, 1, "Eligible rewards should exceed remaining budget before clamping");
+
+        _setTotalClaimedRewardsForEpoch(previousEpoch, userRewardsWithoutCap - 1);
+
+        uint256 aliceBalanceBefore = users.alice.balance;
+
+        vm.expectEmit(true, true, false, true);
+        emit RewardsClaimed(users.alice, users.alice, 1);
+
+        resetPrank(users.alice);
+        protocol.trustBonding.claimRewards(users.alice);
+
+        uint256 epochBudget = protocol.trustBonding.emissionsForEpoch(previousEpoch);
+        uint256 totalClaimed = protocol.trustBonding.totalClaimedRewardsForEpoch(previousEpoch);
+
+        assertEq(users.alice.balance, aliceBalanceBefore + 1);
+        assertEq(protocol.trustBonding.userClaimedRewardsForEpoch(users.alice, previousEpoch), 1);
+        assertEq(totalClaimed, epochBudget);
+        assertLe(totalClaimed, epochBudget);
+    }
+
+    function test_claimRewards_revertsWhenEpochBudgetAlreadyExhausted() external {
+        _createLock(users.alice, initialTokens);
+        _advanceToEpoch(1);
+
+        uint256 previousEpoch = 0;
+        uint256 epochBudget = protocol.trustBonding.emissionsForEpoch(previousEpoch);
+        _setTotalClaimedRewardsForEpoch(previousEpoch, epochBudget);
+
+        vm.expectRevert(ITrustBonding.TrustBonding_EpochBudgetExhausted.selector);
+        resetPrank(users.alice);
+        protocol.trustBonding.claimRewards(users.alice);
+    }
+
+    /// @notice After Alice claims full budget, Bob locks at the start of the next epoch and tries
+    ///         to claim.  Bob has zero eligible rewards for the closing epoch (his lock is excluded
+    ///         from the epoch's snapshot), so he gets NoRewardsToClaim.
+    function test_claimRewards_revertsWhenNextEpochStartLockHasNoEligibleRewards() external {
+        _createLock(users.alice, initialTokens);
+
+        uint256 targetEpoch = 1;
+        uint256 nextEpochStart = protocol.trustBonding.epochTimestampEnd(targetEpoch) + 1;
+
+        vm.warp(nextEpochStart);
+
+        resetPrank(users.alice);
+        protocol.trustBonding.claimRewards(users.alice);
+
+        _createLock(users.bob, initialTokens);
+
+        // Bob's lock at next-epoch-start is excluded from epoch 1's snapshot — no rewards.
+        vm.expectRevert(ITrustBonding.TrustBonding_NoRewardsToClaim.selector);
+        resetPrank(users.bob);
+        protocol.trustBonding.claimRewards(users.bob);
+
+        uint256 totalClaimed = protocol.trustBonding.totalClaimedRewardsForEpoch(targetEpoch);
+        uint256 epochBudget = protocol.trustBonding.emissionsForEpoch(targetEpoch);
+        assertEq(totalClaimed, epochBudget);
+        assertLe(totalClaimed, epochBudget);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    S-595 REGRESSION TEST
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Regression test for S-595: proves that correct epoch boundaries prevent
+    ///         share inflation.  Locks at the start of the next epoch have zero eligible
+    ///         rewards for the prior epoch, so they revert with NoRewardsToClaim (primary
+    ///         defense).  The budget guardrail provides additional defense-in-depth.
+    function test_claimRewards_S595_nextEpochLocksHaveNoEligibleRewards() external {
+        // Alice locks 100 ether before epoch boundary
+        _createLock(users.alice, 100 ether);
+
+        // Advance past epoch 1's end into epoch 2
+        uint256 targetEpoch = 1;
+        uint256 nextEpochStart = protocol.trustBonding.epochTimestampEnd(targetEpoch) + 1;
+        vm.warp(nextEpochStart);
+
+        uint256 epochBudget = protocol.trustBonding.emissionsForEpoch(targetEpoch);
+
+        // Alice claims rewards for epoch 1 — she was the only locker, gets full budget
+        resetPrank(users.alice);
+        protocol.trustBonding.claimRewards(users.alice);
+
+        uint256 totalClaimedAfterAlice = protocol.trustBonding.totalClaimedRewardsForEpoch(targetEpoch);
+        assertEq(totalClaimedAfterAlice, epochBudget, "Alice should claim full epoch budget");
+
+        // Bob locks 5000 ether at next-epoch-start — excluded from epoch 1's snapshot.
+        _createLock(users.bob, 5000 ether);
+
+        // Bob has zero eligible rewards for epoch 1.
+        vm.expectRevert(ITrustBonding.TrustBonding_NoRewardsToClaim.selector);
+        resetPrank(users.bob);
+        protocol.trustBonding.claimRewards(users.bob);
+
+        // Charlie locks 5000 ether at next-epoch-start — same result.
+        _createLock(users.charlie, 5000 ether);
+
+        vm.expectRevert(ITrustBonding.TrustBonding_NoRewardsToClaim.selector);
+        resetPrank(users.charlie);
+        protocol.trustBonding.claimRewards(users.charlie);
+
+        // Invariant: totalClaimed <= epochBudget always holds
+        uint256 finalTotalClaimed = protocol.trustBonding.totalClaimedRewardsForEpoch(targetEpoch);
+        assertLe(finalTotalClaimed, epochBudget, "Invariant: totalClaimed <= epochBudget");
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    FUZZ TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function testFuzz_claimRewards_totalClaimedNeverExceedsBudget(uint256 lockAmount) external {
+        // Bound to reasonable lock amounts (min 1 ether to avoid dust, max 100k ether)
+        lockAmount = bound(lockAmount, 1 ether, 100_000 ether);
+
+        // Ensure alice has enough tokens
+        vm.deal(users.alice, lockAmount * 10);
+        resetPrank(users.alice);
+        protocol.wrappedTrust.deposit{ value: lockAmount }();
+        protocol.wrappedTrust.approve(address(protocol.trustBonding), lockAmount);
+
+        _createLock(users.alice, lockAmount);
+        _advanceToEpoch(1);
+
+        uint256 previousEpoch = 0;
+        uint256 epochBudget = protocol.trustBonding.emissionsForEpoch(previousEpoch);
+
+        resetPrank(users.alice);
+        protocol.trustBonding.claimRewards(users.alice);
+
+        uint256 totalClaimed = protocol.trustBonding.totalClaimedRewardsForEpoch(previousEpoch);
+        assertLe(totalClaimed, epochBudget, "Invariant: totalClaimed <= epochBudget");
+    }
+
+    function testFuzz_claimRewards_totalClaimedNeverExceedsBudget_acrossClaimOrders(uint8 orderSeed) external {
+        orderSeed = uint8(bound(orderSeed, 0, 5));
+
+        _createLock(users.alice, 100 ether);
+        _createLock(users.bob, 60 ether);
+        _createLock(users.charlie, 40 ether);
+        _advanceToEpoch(1);
+
+        uint256 previousEpoch = 0;
+        uint256 epochBudget = protocol.trustBonding.emissionsForEpoch(previousEpoch);
+        address[3] memory claimers = _resolveClaimOrder(orderSeed);
+
+        uint256 runningSum = 0;
+
+        for (uint256 i = 0; i < claimers.length; i++) {
+            address claimer = claimers[i];
+            uint256 expectedRewards = _calculateExpectedRewards(claimer, previousEpoch);
+
+            resetPrank(claimer);
+            protocol.trustBonding.claimRewards(claimer);
+
+            uint256 claimedRewards = protocol.trustBonding.userClaimedRewardsForEpoch(claimer, previousEpoch);
+            runningSum += claimedRewards;
+
+            assertEq(claimedRewards, expectedRewards, "claimed rewards mismatch");
+            assertEq(
+                protocol.trustBonding.totalClaimedRewardsForEpoch(previousEpoch), runningSum, "total claimed mismatch"
+            );
+            assertLe(
+                protocol.trustBonding.totalClaimedRewardsForEpoch(previousEpoch),
+                epochBudget,
+                "Invariant: totalClaimed <= epochBudget"
+            );
+        }
+    }
+
+    function _resolveClaimOrder(uint8 orderSeed) internal view returns (address[3] memory claimers) {
+        if (orderSeed == 0) {
+            claimers[0] = users.alice;
+            claimers[1] = users.bob;
+            claimers[2] = users.charlie;
+            return claimers;
+        }
+        if (orderSeed == 1) {
+            claimers[0] = users.alice;
+            claimers[1] = users.charlie;
+            claimers[2] = users.bob;
+            return claimers;
+        }
+        if (orderSeed == 2) {
+            claimers[0] = users.bob;
+            claimers[1] = users.alice;
+            claimers[2] = users.charlie;
+            return claimers;
+        }
+        if (orderSeed == 3) {
+            claimers[0] = users.bob;
+            claimers[1] = users.charlie;
+            claimers[2] = users.alice;
+            return claimers;
+        }
+        if (orderSeed == 4) {
+            claimers[0] = users.charlie;
+            claimers[1] = users.alice;
+            claimers[2] = users.bob;
+            return claimers;
+        }
+
+        claimers[0] = users.charlie;
+        claimers[1] = users.bob;
+        claimers[2] = users.alice;
+    }
+}

--- a/tests/unit/TrustBonding/ClaimRewards.t.sol
+++ b/tests/unit/TrustBonding/ClaimRewards.t.sol
@@ -96,7 +96,7 @@ contract ClaimRewardsTest is TrustBondingBase {
 
         uint256 aliceBalanceBefore = users.alice.balance;
 
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, true, false, true, address(protocol.trustBonding));
         emit RewardsClaimed(users.alice, users.alice, expectedFinalRewards);
 
         resetPrank(users.alice);

--- a/tests/unit/TrustBonding/Reads.t.sol
+++ b/tests/unit/TrustBonding/Reads.t.sol
@@ -39,7 +39,9 @@ contract TrustBondingReadsTest is TrustBondingBase {
         uint256 currentEpoch = protocol.trustBonding.currentEpoch();
         uint256 endTimestamp = protocol.trustBonding.epochTimestampEnd(currentEpoch);
 
-        uint256 expected = TRUST_BONDING_START_TIMESTAMP + TRUST_BONDING_EPOCH_LENGTH - 20;
+        // SatelliteEmissionsController startTimestamp = block.timestamp (1 in Foundry).
+        // epochEnd(0) = startTimestamp + epochLength - 1 (closed interval).
+        uint256 expected = TRUST_BONDING_EPOCH_LENGTH;
         assertEq(endTimestamp, expected);
     }
 
@@ -51,7 +53,8 @@ contract TrustBondingReadsTest is TrustBondingBase {
         assertEq(epoch1, 1);
 
         uint256 endTimestamp = protocol.trustBonding.epochTimestampEnd(epoch1);
-        uint256 expected = TRUST_BONDING_START_TIMESTAMP + (TRUST_BONDING_EPOCH_LENGTH * 2) - 20;
+        // epochEnd(1) = startTimestamp + 2*epochLength - 1
+        uint256 expected = TRUST_BONDING_EPOCH_LENGTH * 2;
         assertEq(endTimestamp, expected);
     }
 

--- a/tests/unit/TrustBonding/Reads.t.sol
+++ b/tests/unit/TrustBonding/Reads.t.sol
@@ -38,10 +38,10 @@ contract TrustBondingReadsTest is TrustBondingBase {
     function test_epochTimestampEnd_currentEpoch() external view {
         uint256 currentEpoch = protocol.trustBonding.currentEpoch();
         uint256 endTimestamp = protocol.trustBonding.epochTimestampEnd(currentEpoch);
+        uint256 startTimestamp = protocol.satelliteEmissionsController.getStartTimestamp();
+        uint256 epochLength = protocol.trustBonding.epochLength();
 
-        // SatelliteEmissionsController startTimestamp = block.timestamp (1 in Foundry).
-        // epochEnd(0) = startTimestamp + epochLength - 1 (closed interval).
-        uint256 expected = TRUST_BONDING_EPOCH_LENGTH;
+        uint256 expected = startTimestamp + ((currentEpoch + 1) * epochLength) - 1;
         assertEq(endTimestamp, expected);
     }
 
@@ -53,8 +53,9 @@ contract TrustBondingReadsTest is TrustBondingBase {
         assertEq(epoch1, 1);
 
         uint256 endTimestamp = protocol.trustBonding.epochTimestampEnd(epoch1);
-        // epochEnd(1) = startTimestamp + 2*epochLength - 1
-        uint256 expected = TRUST_BONDING_EPOCH_LENGTH * 2;
+        uint256 startTimestamp = protocol.satelliteEmissionsController.getStartTimestamp();
+        uint256 epochLength = protocol.trustBonding.epochLength();
+        uint256 expected = startTimestamp + ((epoch1 + 1) * epochLength) - 1;
         assertEq(endTimestamp, expected);
     }
 

--- a/tests/unit/TrustBonding/TrustBonding.t.sol
+++ b/tests/unit/TrustBonding/TrustBonding.t.sol
@@ -128,10 +128,11 @@ contract TrustBondingTest is TrustBondingBase {
     function test_epochTimestampEnd() external {
         uint256 currentEpoch = protocol.trustBonding.currentEpoch();
         uint256 currentEpochEndTimestamp = protocol.trustBonding.epochTimestampEnd(currentEpoch);
+        uint256 startTimestamp = protocol.satelliteEmissionsController.getStartTimestamp();
+        uint256 epochLength = protocol.trustBonding.epochLength();
+        uint256 expectedEpochEndTimestamp = startTimestamp + ((currentEpoch + 1) * epochLength) - 1;
 
-        // SatelliteEmissionsController startTimestamp = block.timestamp (1 in Foundry).
-        // epochEnd(0) = startTimestamp + epochLength - 1 (closed interval).
-        assertEq(currentEpochEndTimestamp, TRUST_BONDING_EPOCH_LENGTH);
+        assertEq(currentEpochEndTimestamp, expectedEpochEndTimestamp);
 
         // Warp 20 days into the future (should be in the middle of epoch 1)
         vm.warp(TRUST_BONDING_START_TIMESTAMP + TRUST_BONDING_EPOCH_LENGTH + (TRUST_BONDING_EPOCH_LENGTH / 2));

--- a/tests/unit/TrustBonding/TrustBonding.t.sol
+++ b/tests/unit/TrustBonding/TrustBonding.t.sol
@@ -129,7 +129,9 @@ contract TrustBondingTest is TrustBondingBase {
         uint256 currentEpoch = protocol.trustBonding.currentEpoch();
         uint256 currentEpochEndTimestamp = protocol.trustBonding.epochTimestampEnd(currentEpoch);
 
-        assertEq(currentEpochEndTimestamp, TRUST_BONDING_START_TIMESTAMP + TRUST_BONDING_EPOCH_LENGTH - 20);
+        // SatelliteEmissionsController startTimestamp = block.timestamp (1 in Foundry).
+        // epochEnd(0) = startTimestamp + epochLength - 1 (closed interval).
+        assertEq(currentEpochEndTimestamp, TRUST_BONDING_EPOCH_LENGTH);
 
         // Warp 20 days into the future (should be in the middle of epoch 1)
         vm.warp(TRUST_BONDING_START_TIMESTAMP + TRUST_BONDING_EPOCH_LENGTH + (TRUST_BONDING_EPOCH_LENGTH / 2));

--- a/tests/unit/TrustBonding/TrustBondingRegressionTest.t.sol
+++ b/tests/unit/TrustBonding/TrustBondingRegressionTest.t.sol
@@ -123,32 +123,25 @@ contract TrustBondingUpgradeRegressionTest is Test {
         // 3. POST-UPGRADE: the same calls must no longer revert
         // ----------------------------------------------------------
 
-        // (a) Global supply at epoch end should now be readable
+        // (a) Global supply at epoch end should now be readable.
         uint256 totalAtEpoch0 = trustBonding.totalBondedBalanceAtEpochEnd(0);
-        assertEq(totalAtEpoch0, totalAtEpoch0PreBug, "total bonded balance must match pre and post-fix");
+        assertEq(totalAtEpoch0, totalAtEpoch0PreBug, "total bonded balance must match");
 
         // (b) User balance at epoch end must no longer revert either
         assertEq(
-            trustBonding.userBondedBalanceAtEpochEnd(USER0, 0),
-            user0AtEpoch0PreBug,
-            "user 0 bonded balance must match pre and post-fix"
+            trustBonding.userBondedBalanceAtEpochEnd(USER0, 0), user0AtEpoch0PreBug, "user 0 bonded balance must match"
         );
         assertEq(
-            trustBonding.userBondedBalanceAtEpochEnd(USER1, 0),
-            user1AtEpoch0PreBug,
-            "user 1 bonded balance must match pre and post-fix"
+            trustBonding.userBondedBalanceAtEpochEnd(USER1, 0), user1AtEpoch0PreBug, "user 1 bonded balance must match"
         );
         assertEq(
-            trustBonding.userBondedBalanceAtEpochEnd(USER2, 0),
-            user2AtEpoch0PreBug,
-            "user 2 bonded balance must match pre and post-fix"
+            trustBonding.userBondedBalanceAtEpochEnd(USER2, 0), user2AtEpoch0PreBug, "user 2 bonded balance must match"
         );
 
-        // Make sure eligible rewards match pre-upgrade values
         assertEq(
             user0EligibleRewardsPreUpgrade,
             trustBonding.userEligibleRewardsForEpoch(USER0, 0),
-            "user 0 eligible rewards view must match pre and post-fix"
+            "user 0 eligible rewards view must match"
         );
 
         // (c) Claim rewards for USER1 should now succeed


### PR DESCRIPTION
## Summary
Fixes the boundary-accounting reward family:
- **S-112 (Medium):** boundary-time entrants becoming eligible for prior-epoch rewards
- **S-595 (Medium):** claim-order over-allocation beyond epoch emissions budget

## What Was Wrong
- Epoch-end snapshot semantics allowed closed-epoch mutability at the boundary timestamp.
- `claimRewards` accounting could over-distribute in aggregate when boundary ordering changed eligibility, because no strict epoch-budget guardrail was enforced during claim accumulation.

## Why This Fix Works
- Uses boundary-exclusive previous-epoch accounting so boundary-time state changes cannot retroactively affect prior-epoch entitlement.
- Enforces epoch-level budget safety in claim flow so total claimed for an epoch cannot exceed configured emissions.
- Preserves fair epoch separation and removes claim-order amplification.

## Testing / Confirmation
- Added regression coverage for boundary lock timing (boundary and boundary+1 paths).
- Added over-allocation protection checks ensuring:
  - `totalClaimedRewardsForEpoch(epoch) <= emissionsForEpoch(epoch)`
  - claim order does not allow budget overshoot.
- Re-ran TrustBonding reward/claim regression suites and verified invariants remain green.

> [!NOTE]
> These two findings are implemented as one boundary-accounting fix set:
> **S-112 is the root-cause path**, and **S-595 is the budget-impact amplifier / guardrail requirement**.
