### PR TITLE
Fix for bug bounty issue #60: Add explicit system utilization rollover guard to prevent mid-epoch reinitialization

### DIFF
--- a/src/protocol/MultiVault.sol
+++ b/src/protocol/MultiVault.sol
@@ -82,6 +82,9 @@ contract MultiVault is
     /// @notice Mapping of the last 3 active epochs for each user
     mapping(address user => uint256[3] epoch) public userEpochHistory;
 
+    /// @notice Tracks whether system-wide utilization rollover has been initialized for a given epoch
+    mapping(uint256 epoch => bool hasRolledOver) public hasRolledOverSystemUtilization;
+
     /* =================================================== */
     /*                        Errors                       */
     /* =================================================== */
@@ -1525,12 +1528,16 @@ contract MultiVault is
         uint256 currentEpochLocal = _currentEpoch();
         uint256 userLastEpoch = userEpochHistory[user][0];
 
-        // First, handle the system-wide rollover if this is the first action in the new epoch
-        if (currentEpochLocal > 0 && totalUtilization[currentEpochLocal] == 0) {
+        // First, handle the system-wide rollover if this is the first action in the new epoch.
+        // A zero totalUtilization is a valid runtime value and cannot be used as an initialization sentinel.
+        if (currentEpochLocal > 0 && !hasRolledOverSystemUtilization[currentEpochLocal]) {
+            hasRolledOverSystemUtilization[currentEpochLocal] = true;
+
             // Roll over from the immediately previous epoch
             uint256 previousEpoch = currentEpochLocal - 1;
-            if (totalUtilization[previousEpoch] != 0) {
-                totalUtilization[currentEpochLocal] = totalUtilization[previousEpoch];
+            int256 previousEpochUtilization = totalUtilization[previousEpoch];
+            if (previousEpochUtilization != 0 && totalUtilization[currentEpochLocal] == 0) {
+                totalUtilization[currentEpochLocal] = previousEpochUtilization;
             }
         }
 

--- a/tests/unit/MultiVault/RolloverSystemUtilization.t.sol
+++ b/tests/unit/MultiVault/RolloverSystemUtilization.t.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.29;
+
+import { Test } from "forge-std/src/Test.sol";
+import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+import { MultiVault } from "src/protocol/MultiVault.sol";
+import {
+    GeneralConfig,
+    AtomConfig,
+    TripleConfig,
+    WalletConfig,
+    VaultFees,
+    BondingCurveConfig
+} from "src/interfaces/IMultiVaultCore.sol";
+
+contract TrustBondingEpochMock {
+    uint256 internal _currentEpochValue;
+
+    function setCurrentEpoch(uint256 newEpoch) external {
+        _currentEpochValue = newEpoch;
+    }
+
+    function currentEpoch() external view returns (uint256) {
+        return _currentEpochValue;
+    }
+}
+
+contract MultiVaultUtilizationHarness is MultiVault {
+    function addUtilizationForTest(address user, int256 totalValue) external {
+        _addUtilization(user, totalValue);
+    }
+
+    function removeUtilizationForTest(address user, int256 amountToRemove) external {
+        _removeUtilization(user, amountToRemove);
+    }
+
+    function setTotalUtilizationForTest(uint256 epoch, int256 utilization) external {
+        totalUtilization[epoch] = utilization;
+    }
+}
+
+contract RolloverSystemUtilizationTest is Test {
+    MultiVaultUtilizationHarness internal harness;
+    TrustBondingEpochMock internal trustBondingEpochMock;
+
+    function setUp() external {
+        trustBondingEpochMock = new TrustBondingEpochMock();
+        MultiVaultUtilizationHarness implementation = new MultiVaultUtilizationHarness();
+
+        GeneralConfig memory generalConfig = GeneralConfig({
+            admin: address(this),
+            protocolMultisig: address(this),
+            feeDenominator: 10_000,
+            trustBonding: address(trustBondingEpochMock),
+            minDeposit: 1,
+            minShare: 1,
+            atomDataMaxLength: 1,
+            feeThreshold: 1
+        });
+
+        AtomConfig memory atomConfig = AtomConfig({ atomCreationProtocolFee: 0, atomWalletDepositFee: 0 });
+        TripleConfig memory tripleConfig =
+            TripleConfig({ tripleCreationProtocolFee: 0, atomDepositFractionForTriple: 0 });
+        WalletConfig memory walletConfig = WalletConfig({
+            entryPoint: address(1), atomWarden: address(1), atomWalletBeacon: address(1), atomWalletFactory: address(1)
+        });
+        VaultFees memory vaultFees = VaultFees({ entryFee: 0, exitFee: 0, protocolFee: 0 });
+        BondingCurveConfig memory bondingCurveConfig = BondingCurveConfig({ registry: address(1), defaultCurveId: 1 });
+
+        bytes memory initData = abi.encodeWithSelector(
+            MultiVault.initialize.selector,
+            generalConfig,
+            atomConfig,
+            tripleConfig,
+            walletConfig,
+            vaultFees,
+            bondingCurveConfig
+        );
+        TransparentUpgradeableProxy proxy =
+            new TransparentUpgradeableProxy(address(implementation), address(this), initData);
+        harness = MultiVaultUtilizationHarness(payable(address(proxy)));
+    }
+
+    function test_rollover_systemUtilizationInitializedOncePerEpoch_afterZeroCrossing() external {
+        address alice = makeAddr("alice");
+        address bob = makeAddr("bob");
+        address charlie = makeAddr("charlie");
+
+        trustBondingEpochMock.setCurrentEpoch(0);
+        harness.addUtilizationForTest(alice, 1000);
+        assertEq(harness.totalUtilization(0), 1000);
+
+        trustBondingEpochMock.setCurrentEpoch(1);
+        harness.addUtilizationForTest(alice, 500);
+        assertEq(harness.totalUtilization(1), 1500);
+
+        harness.removeUtilizationForTest(bob, 1500);
+        assertEq(harness.totalUtilization(1), 0);
+
+        harness.addUtilizationForTest(charlie, 100);
+        assertEq(harness.totalUtilization(1), 100);
+    }
+
+    function test_rollover_systemUtilizationCarriesPreviousEpoch_onFirstActionOnly() external {
+        address alice = makeAddr("alice");
+        address bob = makeAddr("bob");
+
+        trustBondingEpochMock.setCurrentEpoch(0);
+        harness.addUtilizationForTest(alice, 250);
+
+        trustBondingEpochMock.setCurrentEpoch(1);
+        harness.addUtilizationForTest(alice, 50);
+        assertEq(harness.totalUtilization(1), 300);
+
+        harness.addUtilizationForTest(bob, 25);
+        assertEq(harness.totalUtilization(1), 325);
+    }
+
+    function test_getHasRolledOverSystemUtilizationGetter_returnsExpectedValue() external {
+        address alice = makeAddr("alice");
+
+        assertEq(harness.hasRolledOverSystemUtilization(1), false);
+
+        trustBondingEpochMock.setCurrentEpoch(0);
+        harness.addUtilizationForTest(alice, 100);
+
+        trustBondingEpochMock.setCurrentEpoch(1);
+        harness.addUtilizationForTest(alice, 1);
+
+        assertEq(harness.hasRolledOverSystemUtilization(1), true);
+    }
+
+    function test_rollover_doesNotOverwriteCurrentEpochUtilization_whenAlreadyInitializedPreUpgrade() external {
+        address alice = makeAddr("alice");
+
+        // Simulate an upgrade into the new implementation mid-epoch:
+        // current epoch utilization already exists, while the new rollover flag is still false.
+        harness.setTotalUtilizationForTest(0, 1000);
+        harness.setTotalUtilizationForTest(1, 777);
+
+        trustBondingEpochMock.setCurrentEpoch(1);
+        assertEq(harness.hasRolledOverSystemUtilization(1), false);
+
+        harness.addUtilizationForTest(alice, 5);
+
+        // Must preserve existing epoch utilization and only apply the new delta.
+        assertEq(harness.totalUtilization(1), 782);
+        assertEq(harness.hasRolledOverSystemUtilization(1), true);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the `MultiVault` utilization rollover bug from the CodeArena [bug bounty report #54](https://github.com/code-423n4/intuition-bug-bounty/issues/54) (originally submitted as [issue #60](https://github.com/code-423n4/intuition-bug-bounty/issues/60)), where epoch rollover logic could re-copy prior epoch utilization after a legitimate mid-epoch zero crossing.

## What Was Wrong
System-wide rollover used an implicit zero-value sentinel on signed `int256 totalUtilization`, so a valid runtime value (`0`) could be misread as “not initialized” and trigger another carry-forward from the previous epoch.

## Why This Fix Works
- Adds an explicit per-epoch rollover guard: `hasRolledOverSystemUtilization[epoch]`.
- Executes system carry-forward at most once per epoch.
- Preserves upgrade safety by only copying prior-epoch utilization if current-epoch utilization is still zero, preventing overwrite of already-initialized current-epoch state.

## Testing / Confirmation
- Added/updated targeted rollover regression tests:
  - zero-crossing does not re-trigger carry-forward
  - previous epoch carries on first action only
  - upgrade transition does not overwrite existing current-epoch utilization
- Key test file:
  - `forge test --match-path tests/unit/MultiVault/RolloverSystemUtilization.t.sol -vvv`
