### PR TITLE
Feat: add PAUSER_ROLE and timelock gating to MultiVault

### DIFF
--- a/src/interfaces/IMultiVault.sol
+++ b/src/interfaces/IMultiVault.sol
@@ -165,6 +165,10 @@ interface IMultiVault {
     /// @param amount The amount of protocol fee accrued
     event ProtocolFeeAccrued(uint256 indexed epoch, address indexed sender, uint256 amount);
 
+    /// @notice Emitted when the timelock controller address is updated
+    /// @param timelock The new timelock controller address
+    event TimelockSet(address indexed timelock);
+
     /// @notice Emitted when a protocol fee is transferred to the protocol multisig or the TrustBonding contract
     /// @dev The protocol fee is charged when depositing assets and redeeming shares from the vault, except
     ///      when the contract is paused
@@ -548,6 +552,8 @@ interface IMultiVault {
     function unpause() external;
 
     /// @notice Sets the general configuration parameters
+    /// @dev Updating `_generalConfig.admin` does not grant or revoke `DEFAULT_ADMIN_ROLE`.
+    /// AccessControl role membership is managed separately via role operations.
     function setGeneralConfig(GeneralConfig memory _generalConfig) external;
 
     /// @notice Sets the atom configuration parameters
@@ -564,4 +570,12 @@ interface IMultiVault {
 
     /// @notice Sets the bonding curve configuration parameters
     function setBondingCurveConfig(BondingCurveConfig memory _bondingCurveConfig) external;
+
+    /// @notice Updates the timelock controller address
+    /// @param _timelock The new timelock controller address
+    function setTimelock(address _timelock) external;
+
+    /// @notice Reinitializes the contract to bootstrap the timelock address after upgrade
+    /// @param _timelock The timelock controller address
+    function reinitialize(address _timelock) external;
 }

--- a/src/protocol/MultiVault.sol
+++ b/src/protocol/MultiVault.sol
@@ -48,6 +48,9 @@ contract MultiVault is
     /// @notice Constant representing the burn address, which receives the "ghost (min) shares"
     address public constant BURN_ADDRESS = address(0x000000000000000000000000000000000000dEaD);
 
+    /// @notice Role identifier for addresses that can pause the contract
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
     /* =================================================== */
     /*                  INTERNAL STATE                     */
     /* =================================================== */
@@ -84,6 +87,12 @@ contract MultiVault is
 
     /// @notice Tracks whether system-wide utilization rollover has been initialized for a given epoch
     mapping(uint256 epoch => bool hasRolledOver) public hasRolledOverSystemUtilization;
+
+    /// @notice The address of the parameters timelock controller
+    address public timelock;
+
+    /// @dev Storage gap for future upgrade safety
+    uint256[50] private __gap;
 
     /* =================================================== */
     /*                        Errors                       */
@@ -149,6 +158,20 @@ contract MultiVault is
 
     error MultiVault_InvalidEpoch();
 
+    error MultiVault_OnlyTimelock();
+
+    error MultiVault_ZeroAddress();
+
+    /* =================================================== */
+    /*                      MODIFIERS                      */
+    /* =================================================== */
+
+    /// @notice Restricts function access to the timelock controller
+    modifier onlyTimelock() {
+        if (msg.sender != timelock) revert MultiVault_OnlyTimelock();
+        _;
+    }
+
     /* =================================================== */
     /*                    CONSTRUCTOR                      */
     /* =================================================== */
@@ -187,6 +210,13 @@ contract MultiVault is
             _generalConfig, _atomConfig, _tripleConfig, _walletConfig, _vaultFees, _bondingCurveConfig
         );
         _grantRole(DEFAULT_ADMIN_ROLE, _generalConfig.admin);
+    }
+
+    /// @notice Reinitializer to bootstrap the timelock address after upgrade
+    /// @param _timelock The timelock controller address
+    function reinitialize(address _timelock) external onlyRole(DEFAULT_ADMIN_ROLE) reinitializer(2) {
+        _setTimelock(_timelock);
+        _grantRole(PAUSER_ROLE, generalConfig.admin);
     }
 
     /* =================================================== */
@@ -975,7 +1005,7 @@ contract MultiVault is
     /* =================================================== */
 
     /// @inheritdoc IMultiVault
-    function pause() external onlyRole(DEFAULT_ADMIN_ROLE) whenNotPaused {
+    function pause() external onlyRole(PAUSER_ROLE) whenNotPaused {
         _pause();
     }
 
@@ -985,7 +1015,7 @@ contract MultiVault is
     }
 
     /// @inheritdoc IMultiVault
-    function setGeneralConfig(GeneralConfig memory _generalConfig) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setGeneralConfig(GeneralConfig memory _generalConfig) external onlyTimelock {
         _setGeneralConfig(_generalConfig);
         emit GeneralConfigUpdated(
             _generalConfig.admin,
@@ -1000,19 +1030,19 @@ contract MultiVault is
     }
 
     /// @inheritdoc IMultiVault
-    function setAtomConfig(AtomConfig memory _atomConfig) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setAtomConfig(AtomConfig memory _atomConfig) external onlyTimelock {
         atomConfig = _atomConfig;
         emit AtomConfigUpdated(_atomConfig.atomCreationProtocolFee, _atomConfig.atomWalletDepositFee);
     }
 
     /// @inheritdoc IMultiVault
-    function setTripleConfig(TripleConfig memory _tripleConfig) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setTripleConfig(TripleConfig memory _tripleConfig) external onlyTimelock {
         tripleConfig = _tripleConfig;
         emit TripleConfigUpdated(_tripleConfig.tripleCreationProtocolFee, _tripleConfig.atomDepositFractionForTriple);
     }
 
     /// @inheritdoc IMultiVault
-    function setWalletConfig(WalletConfig memory _walletConfig) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setWalletConfig(WalletConfig memory _walletConfig) external onlyTimelock {
         walletConfig = _walletConfig;
         emit WalletConfigUpdated(
             _walletConfig.entryPoint,
@@ -1023,16 +1053,13 @@ contract MultiVault is
     }
 
     /// @inheritdoc IMultiVault
-    function setVaultFees(VaultFees memory _vaultFees) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setVaultFees(VaultFees memory _vaultFees) external onlyTimelock {
         vaultFees = _vaultFees;
         emit VaultFeesUpdated(_vaultFees.entryFee, _vaultFees.exitFee, _vaultFees.protocolFee);
     }
 
     /// @inheritdoc IMultiVault
-    function setBondingCurveConfig(BondingCurveConfig memory _bondingCurveConfig)
-        external
-        onlyRole(DEFAULT_ADMIN_ROLE)
-    {
+    function setBondingCurveConfig(BondingCurveConfig memory _bondingCurveConfig) external onlyTimelock {
         bondingCurveConfig = _bondingCurveConfig;
         emit BondingCurveConfigUpdated(_bondingCurveConfig.registry, _bondingCurveConfig.defaultCurveId);
     }
@@ -1040,6 +1067,11 @@ contract MultiVault is
     /// @inheritdoc IMultiVault
     function sweepAccumulatedProtocolFees(uint256 epoch) external {
         _claimAccumulatedProtocolFees(epoch);
+    }
+
+    /// @inheritdoc IMultiVault
+    function setTimelock(address _timelock) external onlyTimelock {
+        _setTimelock(_timelock);
     }
 
     /* =================================================== */
@@ -1565,6 +1597,14 @@ contract MultiVault is
         Address.sendValue(payable(generalConfig.protocolMultisig), protocolFees);
 
         emit ProtocolFeeTransferred(epoch, generalConfig.protocolMultisig, protocolFees);
+    }
+
+    /// @dev Internal function to set and validate the timelock address
+    /// @param _timelock The new timelock controller address
+    function _setTimelock(address _timelock) internal {
+        if (_timelock == address(0)) revert MultiVault_ZeroAddress();
+        timelock = _timelock;
+        emit TimelockSet(_timelock);
     }
 
     /// @dev Updates the vault state on creation of a new vault

--- a/src/protocol/MultiVaultMigrationMode.sol
+++ b/src/protocol/MultiVaultMigrationMode.sol
@@ -55,8 +55,6 @@ contract MultiVaultMigrationMode is MultiVault {
 
     error MultiVault_InvalidBondingCurveId();
 
-    error MultiVault_ZeroAddress();
-
     /*//////////////////////////////////////////////////////////////
                              MIGRATION FUNCTIONS
     //////////////////////////////////////////////////////////////*/

--- a/tests/BaseTest.t.sol
+++ b/tests/BaseTest.t.sol
@@ -371,6 +371,10 @@ abstract contract BaseTest is Modifiers, Test {
                 bondingCurveConfig
             );
 
+        // Bootstrap RBAC: set timelock (reinitialize also grants PAUSER_ROLE to generalConfig.admin)
+        resetPrank(users.admin);
+        protocol.multiVault.reinitialize(users.timelock);
+
         resetPrank(users.timelock);
         protocol.trustBonding.setMultiVault(address(protocol.multiVault));
 

--- a/tests/unit/MultiVault/AccessControl.t.sol
+++ b/tests/unit/MultiVault/AccessControl.t.sol
@@ -1,0 +1,457 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.29;
+
+import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+import { IMultiVault } from "src/interfaces/IMultiVault.sol";
+import { MultiVault } from "src/protocol/MultiVault.sol";
+import {
+    GeneralConfig,
+    AtomConfig,
+    TripleConfig,
+    WalletConfig,
+    VaultFees,
+    BondingCurveConfig
+} from "src/interfaces/IMultiVaultCore.sol";
+
+import { BaseTest } from "tests/BaseTest.t.sol";
+
+/// @title MultiVault Access Control Tests
+/// @notice Comprehensive tests for PAUSER_ROLE, onlyTimelock, and DEFAULT_ADMIN_ROLE boundaries
+contract MultiVaultAccessControlTest is BaseTest {
+    /// @dev A dedicated pauser address (not admin) for testing role separation
+    address internal pauser;
+
+    function setUp() public override {
+        super.setUp();
+        pauser = createUser("pauser");
+
+        // Grant PAUSER_ROLE to the dedicated pauser
+        resetPrank(users.admin);
+        protocol.multiVault.grantRole(protocol.multiVault.PAUSER_ROLE(), pauser);
+    }
+
+    /*////////////////////////////////////////////////////////////////////
+                              PAUSER_ROLE TESTS
+    ////////////////////////////////////////////////////////////////////*/
+
+    function test_pause_shouldSucceedWithPauserRole() public {
+        resetPrank(pauser);
+        protocol.multiVault.pause();
+
+        assertTrue(protocol.multiVault.paused());
+    }
+
+    function test_pause_shouldSucceedWithAdminWhoPauserRole() public {
+        // admin also has PAUSER_ROLE (granted in BaseTest setUp)
+        resetPrank(users.admin);
+        protocol.multiVault.pause();
+
+        assertTrue(protocol.multiVault.paused());
+    }
+
+    function test_pause_shouldRevertWithUnauthorizedUser() public {
+        resetPrank(users.alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, users.alice, protocol.multiVault.PAUSER_ROLE()
+            )
+        );
+        protocol.multiVault.pause();
+    }
+
+    function test_pause_shouldRevertWhenAlreadyPaused() public {
+        resetPrank(pauser);
+        protocol.multiVault.pause();
+
+        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        protocol.multiVault.pause();
+    }
+
+    /*////////////////////////////////////////////////////////////////////
+                          UNPAUSE (DEFAULT_ADMIN_ROLE)
+    ////////////////////////////////////////////////////////////////////*/
+
+    function test_unpause_shouldSucceedWithAdminRole() public {
+        resetPrank(pauser);
+        protocol.multiVault.pause();
+
+        resetPrank(users.admin);
+        protocol.multiVault.unpause();
+
+        assertFalse(protocol.multiVault.paused());
+    }
+
+    function test_unpause_shouldRevertWithPauserOnly() public {
+        // Dedicated pauser only has PAUSER_ROLE and no DEFAULT_ADMIN_ROLE
+        resetPrank(pauser);
+        protocol.multiVault.pause();
+
+        // pauser does not have DEFAULT_ADMIN_ROLE, cannot unpause
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                pauser,
+                protocol.multiVault.DEFAULT_ADMIN_ROLE()
+            )
+        );
+        protocol.multiVault.unpause();
+    }
+
+    function test_unpause_shouldRevertWithUnauthorizedUser() public {
+        resetPrank(pauser);
+        protocol.multiVault.pause();
+
+        resetPrank(users.alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                users.alice,
+                protocol.multiVault.DEFAULT_ADMIN_ROLE()
+            )
+        );
+        protocol.multiVault.unpause();
+    }
+
+    function test_unpause_shouldRevertWhenNotPaused() public {
+        resetPrank(users.admin);
+        vm.expectRevert(PausableUpgradeable.ExpectedPause.selector);
+        protocol.multiVault.unpause();
+    }
+
+    /*////////////////////////////////////////////////////////////////////
+                     ONLY_TIMELOCK: setGeneralConfig
+    ////////////////////////////////////////////////////////////////////*/
+
+    function test_setGeneralConfig_shouldSucceedWithTimelock() public {
+        GeneralConfig memory gc = _getDefaultGeneralConfig();
+        gc.minDeposit = gc.minDeposit + 1;
+
+        resetPrank(users.timelock);
+        protocol.multiVault.setGeneralConfig(gc);
+
+        (,,,, uint256 newMinDeposit,,,) = protocol.multiVault.generalConfig();
+        assertEq(newMinDeposit, gc.minDeposit);
+    }
+
+    function test_setGeneralConfig_shouldRevertWithAdmin() public {
+        GeneralConfig memory gc = _getDefaultGeneralConfig();
+
+        resetPrank(users.admin);
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_OnlyTimelock.selector));
+        protocol.multiVault.setGeneralConfig(gc);
+    }
+
+    function test_setGeneralConfig_shouldRevertWithUnauthorizedUser() public {
+        GeneralConfig memory gc = _getDefaultGeneralConfig();
+
+        resetPrank(users.alice);
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_OnlyTimelock.selector));
+        protocol.multiVault.setGeneralConfig(gc);
+    }
+
+    /*////////////////////////////////////////////////////////////////////
+                       ONLY_TIMELOCK: setAtomConfig
+    ////////////////////////////////////////////////////////////////////*/
+
+    function test_setAtomConfig_shouldSucceedWithTimelock() public {
+        AtomConfig memory ac = _getDefaultAtomConfig();
+        ac.atomCreationProtocolFee = ac.atomCreationProtocolFee + 1;
+
+        resetPrank(users.timelock);
+        protocol.multiVault.setAtomConfig(ac);
+
+        (uint256 newFee,) = protocol.multiVault.atomConfig();
+        assertEq(newFee, ac.atomCreationProtocolFee);
+    }
+
+    function test_setAtomConfig_shouldRevertWithAdmin() public {
+        AtomConfig memory ac = _getDefaultAtomConfig();
+
+        resetPrank(users.admin);
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_OnlyTimelock.selector));
+        protocol.multiVault.setAtomConfig(ac);
+    }
+
+    function test_setAtomConfig_shouldRevertWithUnauthorizedUser() public {
+        AtomConfig memory ac = _getDefaultAtomConfig();
+
+        resetPrank(users.alice);
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_OnlyTimelock.selector));
+        protocol.multiVault.setAtomConfig(ac);
+    }
+
+    /*////////////////////////////////////////////////////////////////////
+                      ONLY_TIMELOCK: setTripleConfig
+    ////////////////////////////////////////////////////////////////////*/
+
+    function test_setTripleConfig_shouldSucceedWithTimelock() public {
+        TripleConfig memory tc = _getDefaultTripleConfig();
+        tc.tripleCreationProtocolFee = tc.tripleCreationProtocolFee + 1;
+
+        resetPrank(users.timelock);
+        protocol.multiVault.setTripleConfig(tc);
+
+        (uint256 newFee,) = protocol.multiVault.tripleConfig();
+        assertEq(newFee, tc.tripleCreationProtocolFee);
+    }
+
+    function test_setTripleConfig_shouldRevertWithAdmin() public {
+        TripleConfig memory tc = _getDefaultTripleConfig();
+
+        resetPrank(users.admin);
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_OnlyTimelock.selector));
+        protocol.multiVault.setTripleConfig(tc);
+    }
+
+    function test_setTripleConfig_shouldRevertWithUnauthorizedUser() public {
+        TripleConfig memory tc = _getDefaultTripleConfig();
+
+        resetPrank(users.alice);
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_OnlyTimelock.selector));
+        protocol.multiVault.setTripleConfig(tc);
+    }
+
+    /*////////////////////////////////////////////////////////////////////
+                      ONLY_TIMELOCK: setWalletConfig
+    ////////////////////////////////////////////////////////////////////*/
+
+    function test_setWalletConfig_shouldSucceedWithTimelock() public {
+        WalletConfig memory wc = _getDefaultWalletConfig(address(protocol.atomWalletFactory));
+        wc.atomWarden = address(0xCAFE);
+
+        resetPrank(users.timelock);
+        protocol.multiVault.setWalletConfig(wc);
+
+        (, address newWarden,,) = protocol.multiVault.walletConfig();
+        assertEq(newWarden, address(0xCAFE));
+    }
+
+    function test_setWalletConfig_shouldRevertWithAdmin() public {
+        WalletConfig memory wc = _getDefaultWalletConfig(address(1));
+
+        resetPrank(users.admin);
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_OnlyTimelock.selector));
+        protocol.multiVault.setWalletConfig(wc);
+    }
+
+    function test_setWalletConfig_shouldRevertWithUnauthorizedUser() public {
+        WalletConfig memory wc = _getDefaultWalletConfig(address(1));
+
+        resetPrank(users.alice);
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_OnlyTimelock.selector));
+        protocol.multiVault.setWalletConfig(wc);
+    }
+
+    /*////////////////////////////////////////////////////////////////////
+                       ONLY_TIMELOCK: setVaultFees
+    ////////////////////////////////////////////////////////////////////*/
+
+    function test_setVaultFees_shouldSucceedWithTimelock() public {
+        VaultFees memory vf = _getDefaultVaultFees();
+        vf.entryFee = vf.entryFee + 1;
+
+        resetPrank(users.timelock);
+        protocol.multiVault.setVaultFees(vf);
+
+        (uint256 newEntry,,) = protocol.multiVault.vaultFees();
+        assertEq(newEntry, vf.entryFee);
+    }
+
+    function test_setVaultFees_shouldRevertWithAdmin() public {
+        VaultFees memory vf = _getDefaultVaultFees();
+
+        resetPrank(users.admin);
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_OnlyTimelock.selector));
+        protocol.multiVault.setVaultFees(vf);
+    }
+
+    function test_setVaultFees_shouldRevertWithUnauthorizedUser() public {
+        VaultFees memory vf = _getDefaultVaultFees();
+
+        resetPrank(users.alice);
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_OnlyTimelock.selector));
+        protocol.multiVault.setVaultFees(vf);
+    }
+
+    /*////////////////////////////////////////////////////////////////////
+                   ONLY_TIMELOCK: setBondingCurveConfig
+    ////////////////////////////////////////////////////////////////////*/
+
+    function test_setBondingCurveConfig_shouldSucceedWithTimelock() public {
+        BondingCurveConfig memory bc = _getDefaultBondingCurveConfig();
+        bc.registry = address(protocol.curveRegistry);
+        bc.defaultCurveId = 2;
+
+        resetPrank(users.timelock);
+        protocol.multiVault.setBondingCurveConfig(bc);
+
+        (, uint256 newId) = protocol.multiVault.bondingCurveConfig();
+        assertEq(newId, 2);
+    }
+
+    function test_setBondingCurveConfig_shouldRevertWithAdmin() public {
+        BondingCurveConfig memory bc = _getDefaultBondingCurveConfig();
+
+        resetPrank(users.admin);
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_OnlyTimelock.selector));
+        protocol.multiVault.setBondingCurveConfig(bc);
+    }
+
+    function test_setBondingCurveConfig_shouldRevertWithUnauthorizedUser() public {
+        BondingCurveConfig memory bc = _getDefaultBondingCurveConfig();
+
+        resetPrank(users.alice);
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_OnlyTimelock.selector));
+        protocol.multiVault.setBondingCurveConfig(bc);
+    }
+
+    /*////////////////////////////////////////////////////////////////////
+                        ONLY_TIMELOCK: setTimelock
+    ////////////////////////////////////////////////////////////////////*/
+
+    function test_setTimelock_shouldSucceedWithTimelock() public {
+        address newTimelock = makeAddr("newTimelock");
+
+        resetPrank(users.timelock);
+        protocol.multiVault.setTimelock(newTimelock);
+
+        assertEq(protocol.multiVault.timelock(), newTimelock);
+    }
+
+    function test_setTimelock_shouldRevertWithZeroAddress() public {
+        resetPrank(users.timelock);
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_ZeroAddress.selector));
+        protocol.multiVault.setTimelock(address(0));
+    }
+
+    function test_setTimelock_shouldRevertWithAdmin() public {
+        resetPrank(users.admin);
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_OnlyTimelock.selector));
+        protocol.multiVault.setTimelock(makeAddr("newTimelock"));
+    }
+
+    function test_setTimelock_shouldRevertWithUnauthorizedUser() public {
+        resetPrank(users.alice);
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_OnlyTimelock.selector));
+        protocol.multiVault.setTimelock(makeAddr("newTimelock"));
+    }
+
+    function test_setTimelock_emitsTimelockSetEvent() public {
+        address newTimelock = makeAddr("newTimelock");
+
+        resetPrank(users.timelock);
+        vm.expectEmit(true, true, true, true);
+        emit IMultiVault.TimelockSet(newTimelock);
+        protocol.multiVault.setTimelock(newTimelock);
+    }
+
+    /*////////////////////////////////////////////////////////////////////
+                            REINITIALIZE
+    ////////////////////////////////////////////////////////////////////*/
+
+    function test_reinitialize_cannotBeCalledTwice() public {
+        // reinitialize was already called in BaseTest setUp
+        resetPrank(users.admin);
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        protocol.multiVault.reinitialize(users.timelock);
+    }
+
+    function test_reinitialize_shouldRevertWithNonAdmin() public {
+        // Even if reinitializer weren't already used, non-admin cannot call it
+        resetPrank(users.alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                users.alice,
+                protocol.multiVault.DEFAULT_ADMIN_ROLE()
+            )
+        );
+        protocol.multiVault.reinitialize(users.timelock);
+    }
+
+    /*////////////////////////////////////////////////////////////////////
+                          ROLE MANAGEMENT
+    ////////////////////////////////////////////////////////////////////*/
+
+    function test_adminCanGrantPauserRole() public {
+        address newPauser = makeAddr("newPauser");
+
+        resetPrank(users.admin);
+        protocol.multiVault.grantRole(protocol.multiVault.PAUSER_ROLE(), newPauser);
+
+        assertTrue(protocol.multiVault.hasRole(protocol.multiVault.PAUSER_ROLE(), newPauser));
+    }
+
+    function test_adminCanRevokePauserRole() public {
+        // pauser was granted role in setUp
+        assertTrue(protocol.multiVault.hasRole(protocol.multiVault.PAUSER_ROLE(), pauser));
+
+        resetPrank(users.admin);
+        protocol.multiVault.revokeRole(protocol.multiVault.PAUSER_ROLE(), pauser);
+
+        assertFalse(protocol.multiVault.hasRole(protocol.multiVault.PAUSER_ROLE(), pauser));
+    }
+
+    function test_nonAdminCannotGrantPauserRole() public {
+        address newPauser = makeAddr("newPauser");
+        bytes32 pauserRole = protocol.multiVault.PAUSER_ROLE();
+        bytes32 adminRole = protocol.multiVault.DEFAULT_ADMIN_ROLE();
+
+        resetPrank(users.alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, users.alice, adminRole)
+        );
+        protocol.multiVault.grantRole(pauserRole, newPauser);
+    }
+
+    function test_pauserCannotPauseAfterRoleRevocation() public {
+        // Pauser pauses, admin revokes PAUSER_ROLE, then pauser cannot pause again
+        resetPrank(pauser);
+        protocol.multiVault.pause();
+
+        resetPrank(users.admin);
+        protocol.multiVault.revokeRole(protocol.multiVault.PAUSER_ROLE(), pauser);
+
+        // pauser can no longer pause (role revoked)
+        protocol.multiVault.unpause();
+
+        resetPrank(pauser);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, pauser, protocol.multiVault.PAUSER_ROLE()
+            )
+        );
+        protocol.multiVault.pause();
+    }
+
+    /*////////////////////////////////////////////////////////////////////
+                     TIMELOCK TRANSFER INTEGRATION
+    ////////////////////////////////////////////////////////////////////*/
+
+    function test_timelockTransfer_fullFlow() public {
+        // 1. Current timelock updates config
+        resetPrank(users.timelock);
+        VaultFees memory vf = _getDefaultVaultFees();
+        vf.entryFee = 200;
+        protocol.multiVault.setVaultFees(vf);
+
+        // 2. Transfer timelock to new address
+        address newTimelock = makeAddr("newTimelock");
+        protocol.multiVault.setTimelock(newTimelock);
+
+        // 3. Old timelock can no longer call
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_OnlyTimelock.selector));
+        protocol.multiVault.setVaultFees(vf);
+
+        // 4. New timelock can call
+        resetPrank(newTimelock);
+        vf.entryFee = 300;
+        protocol.multiVault.setVaultFees(vf);
+
+        (uint256 entry,,) = protocol.multiVault.vaultFees();
+        assertEq(entry, 300);
+    }
+}

--- a/tests/unit/MultiVault/AdminFunctions.t.sol
+++ b/tests/unit/MultiVault/AdminFunctions.t.sol
@@ -7,6 +7,7 @@ import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/trans
 
 import { BondingCurveRegistry } from "src/protocol/curves/BondingCurveRegistry.sol";
 import { LinearCurve } from "src/protocol/curves/LinearCurve.sol";
+import { MultiVault } from "src/protocol/MultiVault.sol";
 import {
     GeneralConfig,
     AtomConfig,
@@ -26,7 +27,7 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
                                 INTERNAL HELPERS
     ////////////////////////////////////////////////////////////////////*/
 
-    function _expectUnauthorized(address caller) internal {
+    function _expectUnauthorizedAdmin(address caller) internal {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
@@ -36,12 +37,24 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
         );
     }
 
+    function _expectUnauthorizedPauser(address caller) internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, caller, protocol.multiVault.PAUSER_ROLE()
+            )
+        );
+    }
+
+    function _expectOnlyTimelock() internal {
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_OnlyTimelock.selector));
+    }
+
     /*////////////////////////////////////////////////////////////////////
                                   PAUSE / UNPAUSE
     ////////////////////////////////////////////////////////////////////*/
 
-    function testPause_OnlyAdmin_SetsPausedAndBlocksDeposit() public {
-        // pause as admin
+    function testPause_OnlyPauser_SetsPausedAndBlocksDeposit() public {
+        // pause as admin (who has PAUSER_ROLE)
         resetPrank({ msgSender: users.admin });
         protocol.multiVault.pause();
 
@@ -56,9 +69,9 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
         protocol.multiVault.deposit{ value: 1 ether }(users.alice, bytes32(0), 1, 0);
     }
 
-    function testPause_RevertWhen_CalledByNonAdmin() public {
+    function testPause_RevertWhen_CalledByNonPauser() public {
         resetPrank({ msgSender: users.alice });
-        _expectUnauthorized(users.alice);
+        _expectUnauthorizedPauser(users.alice);
         protocol.multiVault.pause();
     }
 
@@ -75,10 +88,9 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
         protocol.multiVault.unpause();
 
         // Create a valid atom so we can perform a real deposit after unpause
-        // (default curve already exists; deposit into default curve works)
         bytes32 atomId = createSimpleAtom("admin-atom", getAtomCreationCost(), users.admin);
 
-        // Alice deposits into default curve (onlySelf approval OK)
+        // Alice deposits into default curve
         resetPrank({ msgSender: users.alice });
         vm.deal(users.alice, 10 ether);
         uint256 curveId = getDefaultCurveId();
@@ -94,7 +106,7 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
         protocol.multiVault.pause();
 
         resetPrank({ msgSender: users.bob });
-        _expectUnauthorized(users.bob);
+        _expectUnauthorizedAdmin(users.bob);
         protocol.multiVault.unpause();
     }
 
@@ -102,7 +114,7 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
                                setGeneralConfig
     ////////////////////////////////////////////////////////////////////*/
 
-    function testSetGeneralConfig_OnlyAdmin_UpdatesFields() public {
+    function testSetGeneralConfig_OnlyTimelock_UpdatesFields() public {
         // Read current config
         (
             address admin,
@@ -127,7 +139,7 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
             feeThreshold: feeThreshold
         });
 
-        resetPrank({ msgSender: users.admin });
+        resetPrank({ msgSender: users.timelock });
         protocol.multiVault.setGeneralConfig(gc);
 
         // Verify updated
@@ -151,13 +163,12 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
         assertEq(newFeeThreshold, feeThreshold);
     }
 
-    function testSetGeneralConfig_RevertWhen_NonAdmin() public {
-        // Craft a dummy config
+    function testSetGeneralConfig_RevertWhen_NotTimelock() public {
         GeneralConfig memory generalConfig = _getDefaultGeneralConfig();
         generalConfig.protocolMultisig = users.bob;
 
         resetPrank({ msgSender: users.alice });
-        _expectUnauthorized(users.alice);
+        _expectOnlyTimelock();
         protocol.multiVault.setGeneralConfig(generalConfig);
     }
 
@@ -165,13 +176,13 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
                                setAtomConfig
     ////////////////////////////////////////////////////////////////////*/
 
-    function testSetAtomConfig_OnlyAdmin_UpdatesFields() public {
+    function testSetAtomConfig_OnlyTimelock_UpdatesFields() public {
         (uint256 creationFee, uint256 walletDepositFee) = protocol.multiVault.atomConfig();
 
         AtomConfig memory ac =
             AtomConfig({ atomCreationProtocolFee: creationFee + 123, atomWalletDepositFee: walletDepositFee + 5 });
 
-        resetPrank({ msgSender: users.admin });
+        resetPrank({ msgSender: users.timelock });
         protocol.multiVault.setAtomConfig(ac);
 
         (uint256 newCreationFee, uint256 newWalletDepositFee) = protocol.multiVault.atomConfig();
@@ -179,12 +190,12 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
         assertEq(newWalletDepositFee, walletDepositFee + 5);
     }
 
-    function testSetAtomConfig_RevertWhen_NonAdmin() public {
+    function testSetAtomConfig_RevertWhen_NotTimelock() public {
         AtomConfig memory ac = _getDefaultAtomConfig();
         ac.atomWalletDepositFee = ac.atomWalletDepositFee + 1;
 
         resetPrank({ msgSender: users.charlie });
-        _expectUnauthorized(users.charlie);
+        _expectOnlyTimelock();
         protocol.multiVault.setAtomConfig(ac);
     }
 
@@ -192,14 +203,14 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
                                setTripleConfig
     ////////////////////////////////////////////////////////////////////*/
 
-    function testSetTripleConfig_OnlyAdmin_UpdatesFields() public {
+    function testSetTripleConfig_OnlyTimelock_UpdatesFields() public {
         (uint256 creationFee, uint256 atomDepositFrac) = protocol.multiVault.tripleConfig();
 
         TripleConfig memory tc = TripleConfig({
             tripleCreationProtocolFee: creationFee + 1, atomDepositFractionForTriple: atomDepositFrac + 3
         });
 
-        resetPrank({ msgSender: users.admin });
+        resetPrank({ msgSender: users.timelock });
         protocol.multiVault.setTripleConfig(tc);
 
         (uint256 nCreationFee, uint256 nFrac) = protocol.multiVault.tripleConfig();
@@ -207,12 +218,12 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
         assertEq(nFrac, atomDepositFrac + 3);
     }
 
-    function testSetTripleConfig_RevertWhen_NonAdmin() public {
+    function testSetTripleConfig_RevertWhen_NotTimelock() public {
         TripleConfig memory tc = _getDefaultTripleConfig();
         tc.atomDepositFractionForTriple = tc.atomDepositFractionForTriple + 1;
 
         resetPrank({ msgSender: users.alice });
-        _expectUnauthorized(users.alice);
+        _expectOnlyTimelock();
         protocol.multiVault.setTripleConfig(tc);
     }
 
@@ -220,12 +231,12 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
                                setVaultFees (+ fuzz)
     ////////////////////////////////////////////////////////////////////*/
 
-    function testSetVaultFees_OnlyAdmin_UpdatesFields() public {
+    function testSetVaultFees_OnlyTimelock_UpdatesFields() public {
         (uint256 entryFee, uint256 exitFee, uint256 protocolFee) = protocol.multiVault.vaultFees();
 
         VaultFees memory vf = VaultFees({ entryFee: entryFee + 7, exitFee: exitFee + 9, protocolFee: protocolFee + 11 });
 
-        resetPrank({ msgSender: users.admin });
+        resetPrank({ msgSender: users.timelock });
         protocol.multiVault.setVaultFees(vf);
 
         (uint256 nEntry, uint256 nExit, uint256 nProt) = protocol.multiVault.vaultFees();
@@ -234,16 +245,16 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
         assertEq(nProt, protocolFee + 11);
     }
 
-    function testSetVaultFees_RevertWhen_NonAdmin() public {
+    function testSetVaultFees_RevertWhen_NotTimelock() public {
         VaultFees memory vf = _getDefaultVaultFees();
         vf.protocolFee = vf.protocolFee + 1;
 
         resetPrank({ msgSender: users.bob });
-        _expectUnauthorized(users.bob);
+        _expectOnlyTimelock();
         protocol.multiVault.setVaultFees(vf);
     }
 
-    function testFuzz_SetVaultFees_OnlyAdmin(uint16 entryFee, uint16 exitFee, uint16 protocolFee) public {
+    function testFuzz_SetVaultFees_OnlyTimelock(uint16 entryFee, uint16 exitFee, uint16 protocolFee) public {
         // Bound to sensible ranges (<= fee denominator)
         uint256 denom = FEE_DENOMINATOR;
         uint256 e = uint256(entryFee) % (denom + 1);
@@ -252,7 +263,7 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
 
         VaultFees memory vf = VaultFees({ entryFee: e, exitFee: x, protocolFee: p });
 
-        resetPrank({ msgSender: users.admin });
+        resetPrank({ msgSender: users.timelock });
         protocol.multiVault.setVaultFees(vf);
 
         (uint256 ne, uint256 nx, uint256 np) = protocol.multiVault.vaultFees();
@@ -265,7 +276,7 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
                            setBondingCurveConfig
     ////////////////////////////////////////////////////////////////////*/
 
-    function testSetBondingCurveConfig_OnlyAdmin_UpdatesFields() public {
+    function testSetBondingCurveConfig_OnlyTimelock_UpdatesFields() public {
         // Deploy a fresh registry and at least one curve so defaultCurveId=1 is valid
         BondingCurveRegistry newRegImpl = new BondingCurveRegistry();
         TransparentUpgradeableProxy newReg = new TransparentUpgradeableProxy(
@@ -282,9 +293,11 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
 
         resetPrank(users.admin);
         newRegInstance.addBondingCurve(address(lcProxy));
+
         // set to the fresh registry, default curve id 1
         BondingCurveConfig memory bc = BondingCurveConfig({ registry: address(newReg), defaultCurveId: 1 });
 
+        resetPrank({ msgSender: users.timelock });
         protocol.multiVault.setBondingCurveConfig(bc);
 
         (address regAddr, uint256 defId) = protocol.multiVault.bondingCurveConfig();
@@ -292,12 +305,12 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
         assertEq(defId, 1);
     }
 
-    function testSetBondingCurveConfig_RevertWhen_NonAdmin() public {
+    function testSetBondingCurveConfig_RevertWhen_NotTimelock() public {
         BondingCurveConfig memory bc = _getDefaultBondingCurveConfig();
         bc.defaultCurveId = 2;
 
         resetPrank({ msgSender: users.charlie });
-        _expectUnauthorized(users.charlie);
+        _expectOnlyTimelock();
         protocol.multiVault.setBondingCurveConfig(bc);
     }
 
@@ -305,7 +318,7 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
                                setWalletConfig
     ////////////////////////////////////////////////////////////////////*/
 
-    function testSetWalletConfig_OnlyAdmin_UpdatesFields() public {
+    function testSetWalletConfig_OnlyTimelock_UpdatesFields() public {
         (address entryPoint, address atomWarden, address atomWalletBeacon, address atomWalletFactory) =
             protocol.multiVault.walletConfig();
 
@@ -316,7 +329,7 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
             atomWalletFactory: atomWalletFactory // leave same
         });
 
-        resetPrank({ msgSender: users.admin });
+        resetPrank({ msgSender: users.timelock });
         protocol.multiVault.setWalletConfig(wc);
 
         (address nEntry, address nWarden, address nBeacon, address nFactory) = protocol.multiVault.walletConfig();
@@ -332,12 +345,12 @@ contract MultiVaultAdminFunctionsTest is BaseTest {
         atomWalletBeacon;
     }
 
-    function testSetWalletConfig_RevertWhen_NonAdmin() public {
+    function testSetWalletConfig_RevertWhen_NotTimelock() public {
         WalletConfig memory wc = _getDefaultWalletConfig(address(1));
         wc.entryPoint = address(0x99);
 
         resetPrank({ msgSender: users.bob });
-        _expectUnauthorized(users.bob);
+        _expectOnlyTimelock();
         protocol.multiVault.setWalletConfig(wc);
     }
 }

--- a/tests/unit/MultiVault/Deposit.t.sol
+++ b/tests/unit/MultiVault/Deposit.t.sol
@@ -204,7 +204,7 @@ contract DepositTest is BaseTest {
         (address registry, uint256 oldDefault) = protocol.multiVault.bondingCurveConfig();
         uint256 newDefault = oldDefault == 1 ? 2 : 1;
 
-        resetPrank(users.admin);
+        resetPrank(users.timelock);
         protocol.multiVault
             .setBondingCurveConfig(BondingCurveConfig({ registry: registry, defaultCurveId: newDefault }));
 
@@ -215,7 +215,7 @@ contract DepositTest is BaseTest {
         protocol.multiVault.deposit{ value: 1 ether }(users.alice, atomId, newDefault, 0);
 
         // Restore default to keep other tests deterministic (optional)
-        resetPrank(users.admin);
+        resetPrank(users.timelock);
         protocol.multiVault
             .setBondingCurveConfig(BondingCurveConfig({ registry: registry, defaultCurveId: oldDefault }));
     }
@@ -235,7 +235,7 @@ contract DepositTest is BaseTest {
         // For atom, minShareCost = minShare
         uint256 minShare = protocol.multiVault.getGeneralConfig().minShare;
 
-        resetPrank(users.admin);
+        resetPrank(users.timelock);
         // Set minDeposit to very small value to isolate the test case
         protocol.multiVault.setGeneralConfig(_getGeneralConfigWithVerySmallMinDeposit());
 
@@ -271,7 +271,7 @@ contract DepositTest is BaseTest {
         // For triple (or counter), minShareCost = 2 * minShare
         uint256 minShare2x = protocol.multiVault.getGeneralConfig().minShare * 2;
 
-        resetPrank(users.admin);
+        resetPrank(users.timelock);
         // Set minDeposit to very small value to isolate the test case
         protocol.multiVault.setGeneralConfig(_getGeneralConfigWithVerySmallMinDeposit());
 
@@ -548,7 +548,7 @@ contract DefaultCurveEntryFeeImpactTest is BaseTest {
     function _setFeeThreshold(uint256 newThreshold) internal {
         GeneralConfig memory gc = _gc();
         gc.feeThreshold = newThreshold;
-        vm.prank(gc.admin);
+        vm.prank(users.timelock);
         protocol.multiVault.setGeneralConfig(gc);
     }
 }

--- a/tests/unit/MultiVault/FeeFlows.t.sol
+++ b/tests/unit/MultiVault/FeeFlows.t.sol
@@ -50,7 +50,7 @@ contract FeeFlowsTest is BaseTest {
     function _setFeeThreshold(uint256 newThreshold) internal {
         GeneralConfig memory gc = _gc();
         gc.feeThreshold = newThreshold;
-        vm.prank(gc.admin);
+        vm.prank(users.timelock);
         protocol.multiVault.setGeneralConfig(gc);
     }
 

--- a/tests/unit/MultiVault/Helpers.t.sol
+++ b/tests/unit/MultiVault/Helpers.t.sol
@@ -92,8 +92,8 @@ contract MultiVaultHelpersTest is BaseTest {
         // expect default atom warden address
         assertEq(protocol.multiVault.getAtomWarden(), ATOM_WARDEN);
 
-        // update via admin and verify
-        resetPrank({ msgSender: users.admin });
+        // update via timelock and verify
+        resetPrank({ msgSender: users.timelock });
         (address entryPoint,, address beacon, address factory) = protocol.multiVault.walletConfig();
         protocol.multiVault
             .setWalletConfig(

--- a/tests/unit/MultiVault/MultiVaultUpgradeRegression.t.sol
+++ b/tests/unit/MultiVault/MultiVaultUpgradeRegression.t.sol
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.29;
+
+import { Test } from "forge-std/src/Test.sol";
+
+import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {
+    ITransparentUpgradeableProxy
+} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+import { MultiVault } from "src/protocol/MultiVault.sol";
+import { GeneralConfig } from "src/interfaces/IMultiVaultCore.sol";
+
+/// @title MultiVault Upgrade Regression Test
+/// @notice Fork-based test verifying that the RBAC hardening upgrade preserves state and activates new access controls
+/// @dev Uses Intuition Mainnet.
+contract MultiVaultUpgradeRegressionTest is Test {
+    // --- Intuition Mainnet addresses (chain ID 1155) ---
+    // These should be updated to mainnet addresses for production regression testing
+    address internal constant MULTIVAULT_PROXY = 0x6E35cF57A41fA15eA0EaE9C33e751b01A784Fe7e;
+    address internal constant UPGRADES_TIMELOCK = 0x321e5d4b20158648dFd1f360A79CAFc97190bAd1;
+    address internal constant PROXY_ADMIN = 0x1999faD6477e4fa9aA0FF20DaafC32F7B90005C8;
+    uint256 internal constant INTUITION_FORK_BLOCK = 2_369_449;
+
+    // --- State snapshots ---
+    MultiVault internal multiVault;
+    ProxyAdmin internal proxyAdmin;
+
+    // Pre-upgrade state
+    uint256 internal preUpgradeTotalTerms;
+    address internal preUpgradeAdmin;
+    address internal preUpgradeMultisig;
+    uint256 internal preUpgradeFeeDenominator;
+    uint256 internal preUpgradeMinDeposit;
+
+    function setUp() external {
+        vm.createSelectFork("intuition", INTUITION_FORK_BLOCK);
+
+        multiVault = MultiVault(MULTIVAULT_PROXY);
+        proxyAdmin = ProxyAdmin(PROXY_ADMIN);
+
+        // Snapshot pre-upgrade state
+        preUpgradeTotalTerms = multiVault.totalTermsCreated();
+        (preUpgradeAdmin, preUpgradeMultisig, preUpgradeFeeDenominator,, preUpgradeMinDeposit,,,) =
+            multiVault.generalConfig();
+    }
+
+    function test_upgradePreservesStateAndActivatesRBAC() external {
+        // 1. Deploy new implementation
+        MultiVault newImpl = new MultiVault();
+
+        // 2. Upgrade via ProxyAdmin (as upgrades timelock)
+        vm.startPrank(UPGRADES_TIMELOCK);
+        proxyAdmin.upgradeAndCall(ITransparentUpgradeableProxy(payable(MULTIVAULT_PROXY)), address(newImpl), bytes(""));
+        vm.stopPrank();
+
+        // 3. Verify state preserved
+        assertEq(multiVault.totalTermsCreated(), preUpgradeTotalTerms, "totalTermsCreated changed");
+        (address admin, address multisig, uint256 feeDenom,, uint256 minDep,,,) = multiVault.generalConfig();
+        assertEq(admin, preUpgradeAdmin, "admin changed");
+        assertEq(multisig, preUpgradeMultisig, "protocolMultisig changed");
+        assertEq(feeDenom, preUpgradeFeeDenominator, "feeDenominator changed");
+        assertEq(minDep, preUpgradeMinDeposit, "minDeposit changed");
+
+        // 4. Verify timelock is unset (zero before reinitialize)
+        assertEq(multiVault.timelock(), address(0), "timelock should be zero before reinitialize");
+
+        // 5. Admin calls reinitialize to set timelock
+        assertTrue(
+            multiVault.hasRole(multiVault.DEFAULT_ADMIN_ROLE(), preUpgradeAdmin),
+            "preUpgradeAdmin must hold DEFAULT_ADMIN_ROLE"
+        );
+        vm.startPrank(preUpgradeAdmin);
+        multiVault.reinitialize(preUpgradeAdmin); // Set admin as initial timelock
+        vm.stopPrank();
+
+        assertEq(multiVault.timelock(), preUpgradeAdmin, "timelock should be admin after reinitialize");
+
+        // 6. Verify config setters now require timelock (admin IS the timelock temporarily)
+        vm.startPrank(preUpgradeAdmin);
+        GeneralConfig memory gc = GeneralConfig({
+            admin: preUpgradeAdmin,
+            protocolMultisig: preUpgradeMultisig,
+            feeDenominator: preUpgradeFeeDenominator,
+            trustBonding: address(0),
+            minDeposit: preUpgradeMinDeposit + 1,
+            minShare: 0,
+            atomDataMaxLength: 0,
+            feeThreshold: 0
+        });
+        // This should succeed since admin is currently the timelock
+        multiVault.setGeneralConfig(gc);
+        vm.stopPrank();
+
+        // 7. Non-timelock user cannot call config setters
+        address randomUser = makeAddr("random");
+        vm.startPrank(randomUser);
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_OnlyTimelock.selector));
+        multiVault.setGeneralConfig(gc);
+        vm.stopPrank();
+
+        // 8. Verify reinitialize granted PAUSER_ROLE to admin and pause works
+        assertTrue(multiVault.hasRole(multiVault.PAUSER_ROLE(), preUpgradeAdmin), "admin should have PAUSER_ROLE");
+        vm.startPrank(preUpgradeAdmin);
+        multiVault.pause();
+        assertTrue(multiVault.paused(), "should be paused");
+        multiVault.unpause();
+        assertFalse(multiVault.paused(), "should be unpaused");
+        vm.stopPrank();
+
+        // 9. User without PAUSER_ROLE cannot pause
+        vm.startPrank(randomUser);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, randomUser, multiVault.PAUSER_ROLE()
+            )
+        );
+        multiVault.pause();
+        vm.stopPrank();
+
+        // 10. Transfer timelock to a new address and verify old timelock loses access
+        address newTimelock = makeAddr("newTimelock");
+        vm.startPrank(preUpgradeAdmin);
+        multiVault.setTimelock(newTimelock);
+        vm.stopPrank();
+
+        assertEq(multiVault.timelock(), newTimelock, "timelock should be updated");
+
+        // Old timelock (admin) can no longer call config setters
+        vm.startPrank(preUpgradeAdmin);
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_OnlyTimelock.selector));
+        multiVault.setGeneralConfig(gc);
+        vm.stopPrank();
+
+        // New timelock can call config setters
+        vm.startPrank(newTimelock);
+        multiVault.setGeneralConfig(gc);
+        vm.stopPrank();
+    }
+
+    function test_reinitializeCannotBeCalledTwice() external {
+        // Deploy and upgrade
+        MultiVault newImpl = new MultiVault();
+        vm.startPrank(UPGRADES_TIMELOCK);
+        proxyAdmin.upgradeAndCall(ITransparentUpgradeableProxy(payable(MULTIVAULT_PROXY)), address(newImpl), bytes(""));
+        vm.stopPrank();
+
+        // First reinitialize succeeds
+        vm.startPrank(preUpgradeAdmin);
+        multiVault.reinitialize(preUpgradeAdmin);
+
+        // Second reinitialize reverts
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        multiVault.reinitialize(preUpgradeAdmin);
+        vm.stopPrank();
+    }
+
+    function test_reinitializeRevertsForNonAdmin() external {
+        // Deploy and upgrade
+        MultiVault newImpl = new MultiVault();
+        vm.startPrank(UPGRADES_TIMELOCK);
+        proxyAdmin.upgradeAndCall(ITransparentUpgradeableProxy(payable(MULTIVAULT_PROXY)), address(newImpl), bytes(""));
+        vm.stopPrank();
+
+        // Non-admin cannot call reinitialize
+        address randomUser = makeAddr("random");
+        vm.startPrank(randomUser);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, randomUser, multiVault.DEFAULT_ADMIN_ROLE()
+            )
+        );
+        multiVault.reinitialize(randomUser);
+        vm.stopPrank();
+    }
+}

--- a/tests/unit/MultiVaultMigrationMode/MultiVaultMigrationMode.t.sol
+++ b/tests/unit/MultiVaultMigrationMode/MultiVaultMigrationMode.t.sol
@@ -521,7 +521,7 @@ contract MultiVaultMigrationModeTest is BaseTest {
                 termIds: termIds, bondingCurveId: 1, users: users_array, userBalances: userBalances
             });
 
-        vm.expectRevert(abi.encodeWithSelector(MultiVaultMigrationMode.MultiVault_ZeroAddress.selector));
+        vm.expectRevert(abi.encodeWithSelector(MultiVault.MultiVault_ZeroAddress.selector));
         vm.prank(users.admin);
         multiVaultMigrationMode.batchSetUserBalances(params);
     }

--- a/tests/unit/TrustBonding/TrustBonding.t.sol
+++ b/tests/unit/TrustBonding/TrustBonding.t.sol
@@ -137,10 +137,11 @@ contract TrustBondingTest is TrustBondingBase {
         // Warp 20 days into the future (should be in the middle of epoch 1)
         vm.warp(TRUST_BONDING_START_TIMESTAMP + TRUST_BONDING_EPOCH_LENGTH + (TRUST_BONDING_EPOCH_LENGTH / 2));
 
-        // currentEpoch = protocol.trustBonding.currentEpoch();
-        // currentEpochEndTimestamp = protocol.trustBonding.epochTimestampEnd(currentEpoch);
+        currentEpoch = protocol.trustBonding.currentEpoch();
+        currentEpochEndTimestamp = protocol.trustBonding.epochTimestampEnd(currentEpoch);
+        expectedEpochEndTimestamp = startTimestamp + ((currentEpoch + 1) * epochLength) - 1;
 
-        // assertEq(currentEpochEndTimestamp, TRUST_BONDING_START_TIMESTAMP + TRUST_BONDING_EPOCH_LENGTH * 2);
+        assertEq(currentEpochEndTimestamp, expectedEpochEndTimestamp);
     }
 
     function test_epochAtTimestamp() external {


### PR DESCRIPTION
## Summary

This PR hardens MultiVault access control to match the TrustBonding pattern:

- **PAUSER_ROLE** now gates `pause()` — separates pause authority from full admin
- **onlyTimelock** modifier gates all 6 config setters (`setGeneralConfig`, `setAtomConfig`, `setTripleConfig`, `setWalletConfig`, `setVaultFees`, `setBondingCurveConfig`) behind the parameters timelock controller
- **`unpause()`** stays under `DEFAULT_ADMIN_ROLE` so the admin Safe multisig can still recover in emergencies
- **`reinitialize()`** bootstraps the timelock address post-upgrade, gated by `DEFAULT_ADMIN_ROLE` (one-shot via `reinitializer(2)`)
- **`setTimelock()`** lets the timelock rotate itself if needed
- New `timelock` state variable at slot 34 + `uint256[50]` storage gap — no changes to the `MultiVaultCore`, storage layout is safe and intact

### Operational steps after upgrade

1. Admin calls `reinitialize(parametersTimelockAddress)` to set the timelock and grant the `PAUSER_ROLE` to the `generalConfig.admin`
2. Optional: Admin calls `grantRole(PAUSER_ROLE, pauserAddress)` via Safe to enable pause authority (note that multiple accounts can hold `PAUSER_ROLE` at the same time, and for this reason, we might want to create a new pauser Safe with a lower threshold, e.g. 2/8 and assign the `PAUSER_ROLE` to it as well)